### PR TITLE
fix: remove paths from hostname for jwks uri

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ export class SgidClient {
       authorization_endpoint: `${hostname}/v${apiVersion}/oauth/authorize`,
       token_endpoint: `${hostname}/v${apiVersion}/oauth/token`,
       userinfo_endpoint: `${hostname}/v${apiVersion}/oauth/userinfo`,
-      jwks_uri: `${hostname}/.well-known/jwks.json`,
+      jwks_uri: `${new URL(hostname).origin}/.well-known/jwks.json`,
     })
 
     this.sgID = new Client({


### PR DESCRIPTION
## Problem

The `jwks_uri` should not contain paths from the given `hostname`.

## Solution

Remove the path component from the given `hostname` in the construction of the `jwks_uri`.