### PR TITLE
fix: check that encKey and data are defined before attempting decrypt

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -142,14 +142,17 @@ export class SgidClient {
       key: encryptedPayloadKey,
       data,
     } = await this.sgID.userinfo<{
-      sub: string
-      key: string
-      data: Record<string, string>
+      sub: string | undefined
+      key: string | undefined
+      data: Record<string, string> | undefined
     }>(accessToken)
 
-    const result = await this.decryptPayload(encryptedPayloadKey, data)
+    if (encryptedPayloadKey && data) {
+      const result = await this.decryptPayload(encryptedPayloadKey, data)
+      return { sub, data: result }
+    }
 
-    return { sub, data: result }
+    return { sub, data: {} }
   }
 
   private async decryptPayload(


### PR DESCRIPTION
# Problem
Currently, the `userinfo` method expects to receive a response from the sgid userinfo endpoint that has the type:
```
{
  sub: string
  key: string
  data: Record<string, string>
}
```

However, if you check the [userinfo controller](https://github.com/datagovsg/sgid-server/blob/develop/src/controllers/transaction/userinfo.controller.ts) in the sgid-server repo, this shape is not correct: in particular, the key and data attributes are possibly of type `undefined`. This happens when the client scope is just `openid` (i.e. it doesn't request any data fields). In such cases, the decrypt payload step fails because it attempts to decrypt the payload using a key that is undefined.

This PR addresses issue #12

## Solution
This PR checks that the `encryptedPayloadKey` and `data` are not undefined before attempting to decrypt the payload.
