### PR TITLE
chore: Upgrade openid-client to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "jose": "4.9.2",
         "node-rsa": "1.1.1",
-        "openid-client": "5.1.5"
+        "openid-client": "^5.4.0"
       },
       "devDependencies": {
         "@types/node": "*",
@@ -1989,9 +1989,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -2221,9 +2221,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -2391,18 +2391,23 @@
       }
     },
     "node_modules/openid-client": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.1.5.tgz",
-      "integrity": "sha512-m41p7V/iXyqc0WZeo20uwKk8NPDAtYd3JS0uWjttcqwvFo4YNYAKegMAMea1qG5RClddQ6rV9ec/TP6ZvsCrYw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.4.0.tgz",
+      "integrity": "sha512-hgJa2aQKcM2hn3eyVtN12tEA45ECjTJPXCgUh5YzTzy9qwapCvmDTVPWOcWVL0d34zeQoQ/hbG9lJhl3AYxJlQ==",
       "dependencies": {
-        "jose": "^4.1.4",
+        "jose": "^4.10.0",
         "lru-cache": "^6.0.0",
         "object-hash": "^2.0.1",
         "oidc-token-hash": "^5.0.1"
       },
-      "engines": {
-        "node": "^12.19.0 || ^14.15.0 || ^16.13.0"
-      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/jose": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.13.1.tgz",
+      "integrity": "sha512-MSJQC5vXco5Br38mzaQKiq9mwt7lwj2eXpgpRyQYNHYt2lq1PjkWa7DLXX0WVcQLE9HhMh3jPiufS7fhJf+CLQ==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -4841,9 +4846,9 @@
       "dev": true
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
@@ -5035,9 +5040,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -5168,14 +5173,21 @@
       }
     },
     "openid-client": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.1.5.tgz",
-      "integrity": "sha512-m41p7V/iXyqc0WZeo20uwKk8NPDAtYd3JS0uWjttcqwvFo4YNYAKegMAMea1qG5RClddQ6rV9ec/TP6ZvsCrYw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.4.0.tgz",
+      "integrity": "sha512-hgJa2aQKcM2hn3eyVtN12tEA45ECjTJPXCgUh5YzTzy9qwapCvmDTVPWOcWVL0d34zeQoQ/hbG9lJhl3AYxJlQ==",
       "requires": {
-        "jose": "^4.1.4",
+        "jose": "^4.10.0",
         "lru-cache": "^6.0.0",
         "object-hash": "^2.0.1",
         "oidc-token-hash": "^5.0.1"
+      },
+      "dependencies": {
+        "jose": {
+          "version": "4.13.1",
+          "resolved": "https://registry.npmjs.org/jose/-/jose-4.13.1.tgz",
+          "integrity": "sha512-MSJQC5vXco5Br38mzaQKiq9mwt7lwj2eXpgpRyQYNHYt2lq1PjkWa7DLXX0WVcQLE9HhMh3jPiufS7fhJf+CLQ=="
+        }
       }
     },
     "optionator": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
   "dependencies": {
     "jose": "4.9.2",
     "node-rsa": "1.1.1",
-    "openid-client": "5.1.5"
+    "openid-client": "5.4.0"
   }
 }


### PR DESCRIPTION
## Problem 
`openid-client` shows warnings on npm install on Node 18.  Closes #22.
There are also 2 dependency vulnerabilities flagged by `npm`.

## Solution
Installed latest version of `openid-client@5.40`. 
Also ran `npm audit fix` to fix dependency vulnerabilities.

## Before & After Screenshots

**BEFORE**:
On `npm i` on Node 18, the below warnings would appear:
```
➜  sgid-client git:(develop) npm i
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'openid-client@5.1.5',
npm WARN EBADENGINE   required: { node: '^12.19.0 || ^14.15.0 || ^16.13.0' },
npm WARN EBADENGINE   current: { node: 'v18.15.0', npm: '9.5.0' }
npm WARN EBADENGINE }

> @opengovsg/sgid-client@1.0.4 prepare
> husky install

husky - Git hooks installed

added 302 packages, and audited 303 packages in 34s

26 packages are looking for funding
  run `npm fund` for details

2 high severity vulnerabilities

To address all issues, run:
  npm audit fix

Run `npm audit` for details.
```

**AFTER**:
On `npm i` on Node 18, there should be no warnings:
```
➜  sgid-client git:(chore/upgrade-openid) npm i

> @opengovsg/sgid-client@1.0.4 prepare
> husky install

husky - Git hooks installed

up to date, audited 304 packages in 567ms

27 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

**New dependencies**:

- `openid-client@5.4.0`: Includes [resolution of Node 18 warnings through the removal of package.json engines requirement](https://github.com/panva/node-openid-client/releases/tag/v5.1.10)
