### PR TITLE
build: include only relevant files in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "The official TypeScript/JavaScript SDK for sgID",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": ["dist"],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "test": "jest",


### PR DESCRIPTION
## Problem

Currently, the npm package includes all the files in the repo, as seen in this screenshot. This adds unnecessary bloat to the package.
<img width="365" alt="Screenshot 2023-04-11 at 7 26 17 PM" src="https://user-images.githubusercontent.com/29480346/231147563-c33fbc99-8830-4f76-9394-04b00ad9e381.png">

## Solution

Include only relevant files. This reduces the package size as follows:
- package size: 22.5kb -> 5.8kb
- unpacked size: 66.5kb -> 18.8kb

### Before
```
npm notice
npm notice 📦  @opengovsg/sgid-client@1.0.4
npm notice === Tarball Contents ===
npm notice 2.2kB  .eslintrc
npm notice 1.3kB  .github/workflows/ci.yml
npm notice 834B   .github/workflows/npmpublish.yml
npm notice 61B    .husky/pre-commit
npm notice 82B    .prettierrc.js
npm notice 3.8kB  CREDITS.md
npm notice 1.1kB  LICENSE
npm notice 1.8kB  README.md
npm notice 1.8kB  dist/index.d.ts
npm notice 11.7kB dist/index.js
npm notice 122B   dist/util.d.ts
npm notice 543B   dist/util.js
npm notice 166B   jest.config.js
npm notice 651B   jest.setup.js
npm notice 1.8kB  package.json
npm notice 1.3kB  sgid-logo.png
npm notice 6.0kB  src/index.ts
npm notice 223B   src/util.ts
npm notice 1.4kB  test/mocks/constants.ts
npm notice 3.9kB  test/mocks/handlers.ts
npm notice 1.4kB  test/mocks/helpers.ts
npm notice 2.2kB  test/mocks/mockClientKeys.json
npm notice 1.7kB  test/mocks/mockPrivateKey.pem
npm notice 1.7kB  test/mocks/mockPrivateKeyPkcs8.pem
npm notice 450B   test/mocks/mockPublicJwks.json
npm notice 226B   test/mocks/server.ts
npm notice 11.8kB test/SgidClient.spec.ts
npm notice 66B    tsconfig.build.json
npm notice 6.1kB  tsconfig.json
npm notice === Tarball Details ===
npm notice name:          @opengovsg/sgid-client
npm notice version:       1.0.4
npm notice filename:      opengovsg-sgid-client-1.0.4.tgz
npm notice package size:  22.5 kB
npm notice unpacked size: 66.5 kB
npm notice shasum:        b329c63072149c9f6065b43d10ca95db124a7e4c
npm notice integrity:     sha512-fTPfRfT2lNOf1[...]zhcqDuotmlA7Q==
npm notice total files:   29
npm notice
opengovsg-sgid-client-1.0.4.tgz
```
### After
```
npm notice
npm notice 📦  @opengovsg/sgid-client@1.0.4
npm notice === Tarball Contents ===
npm notice 1.1kB  LICENSE
npm notice 1.8kB  README.md
npm notice 1.8kB  dist/index.d.ts
npm notice 11.7kB dist/index.js
npm notice 122B   dist/util.d.ts
npm notice 543B   dist/util.js
npm notice 1.8kB  package.json
npm notice === Tarball Details ===
npm notice name:          @opengovsg/sgid-client
npm notice version:       1.0.4
npm notice filename:      opengovsg-sgid-client-1.0.4.tgz
npm notice package size:  5.8 kB
npm notice unpacked size: 18.8 kB
npm notice shasum:        d48cc2654211f5936ce5ba82f77b39f275bda589
npm notice integrity:     sha512-fuaggrcvo7n99[...]hAV/N8axaGE4w==
npm notice total files:   7
npm notice
opengovsg-sgid-client-1.0.4.tgz
```