### PR TITLE
feat: PKCE `codeVerifier`, `codeChallenge`, and `authorizationUrl`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,17 +84,17 @@ export class SgidClient {
   ): { url: string; nonce?: string } {
     switch (this.apiVersion) {
       case 1:
-        return this.authorizationUrlV1(state, scope, nonce, redirectUri)
+        return this.authorizationUrlV1({ state, scope, nonce, redirectUri })
 
       case 2:
-        return this.authorizationUrlV2(
+        return this.authorizationUrlV2({
           state,
           scope,
           nonce,
           redirectUri,
-          codeChallengeMethod,
           codeChallenge,
-        )
+          codeChallengeMethod,
+        })
 
       default:
         // TODO: Should the checking be done in the constructor?
@@ -103,13 +103,17 @@ export class SgidClient {
     }
   }
 
-  //TODO: Should we use an object as a parameter instead
-  private authorizationUrlV1(
-    state: string,
-    scope: string | string[],
-    nonce: string | null,
-    redirectUri: string,
-  ): { url: string; nonce?: string } {
+  private authorizationUrlV1({
+    state,
+    scope,
+    nonce,
+    redirectUri,
+  }: {
+    state: string
+    scope: string | string[]
+    nonce: string | null
+    redirectUri: string
+  }): { url: string; nonce?: string } {
     const url = this.sgID.authorizationUrl({
       scope: typeof scope === 'string' ? scope : scope.join(' '),
       nonce: nonce ?? undefined,
@@ -123,14 +127,21 @@ export class SgidClient {
     return result
   }
 
-  private authorizationUrlV2(
-    state: string,
-    scope: string | string[],
-    nonce: string | null,
-    redirectUri: string,
-    codeChallengeMethod: 'plain' | 'S256',
-    codeChallenge?: string,
-  ): { url: string; nonce?: string } {
+  private authorizationUrlV2({
+    state,
+    scope,
+    nonce,
+    redirectUri,
+    codeChallenge,
+    codeChallengeMethod,
+  }: {
+    state: string
+    scope: string | string[]
+    nonce: string | null
+    redirectUri: string
+    codeChallenge?: string
+    codeChallengeMethod: 'plain' | 'S256'
+  }): { url: string; nonce?: string } {
     if (codeChallenge === undefined) {
       // eslint-disable-next-line typesafe/no-throw-sync-func
       throw new Error('Code challenge must be provided when using apiVersion 2')

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,6 +194,35 @@ export class SgidClient {
     }
     return result
   }
+
+  /**
+   * Generates the code verifier (random bytes encoded in url safe base 64) to be used in the OAuth 2.0 PKCE flow
+   * @param length The length of the code verifier to generate (Defaults to 43 if not provided)
+   * @returns The generated code verifier
+   */
+  codeVerifier(length = 43): string {
+    if (length < 43 || length > 128) {
+      // eslint-disable-next-line typesafe/no-throw-sync-func
+      throw new Error(
+        `The code verifier should have a minimum length of 43 and a maximum length of 128. Length of ${length} was provided`,
+      )
+    }
+
+    // 96 bytes results in a 128 long base64 string
+    const codeVerifier = generators.codeVerifier(96)
+
+    // This works because a prefix of a random string is still random
+    return codeVerifier.slice(0, length)
+  }
+
+  /**
+   * Calculates the S256 PKCE code challenge for a provided code verifier
+   * @param codeVerifier The code verifier to calculate the S256 code challenge for
+   * @returns The calculated code challenge
+   */
+  codeChallenge(codeVerifier: string): string {
+    return generators.codeChallenge(codeVerifier)
+  }
 }
 
 export default SgidClient

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,8 @@ import {
 import { convertPkcs1ToPkcs8 } from './util'
 
 const SGID_SIGNING_ALG = 'RS256'
-const SGID_CODE_CHALLENGE_METHOD = 'S256'
+export const DEFAULT_SGID_CODE_CHALLENGE_METHOD = 'S256'
+export const DEFAULT_SCOPE = 'myinfo.nric_number openid'
 const SGID_SUPPORTED_FLOWS: ResponseType[] = ['code']
 const SGID_AUTH_METHOD: ClientAuthMethod = 'client_secret_post'
 
@@ -76,11 +77,11 @@ export class SgidClient {
    */
   authorizationUrl(
     state: string,
-    scope: string | string[] = 'myinfo.nric_number openid',
+    scope: string | string[] = DEFAULT_SCOPE,
     nonce: string | null = generators.nonce(),
     redirectUri: string = this.getFirstRedirectUri(),
-    codeChallengeMethod: 'plain' | 'S256' = SGID_CODE_CHALLENGE_METHOD,
     codeChallenge?: string,
+    codeChallengeMethod: 'plain' | 'S256' = DEFAULT_SGID_CODE_CHALLENGE_METHOD,
   ): { url: string; nonce?: string } {
     switch (this.apiVersion) {
       case 1:

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,3 +7,9 @@ export function convertPkcs1ToPkcs8(pkcs1: string): string {
   const key = new NodeRSA(pkcs1, 'pkcs1')
   return key.exportKey('pkcs8')
 }
+
+/**
+ * Regex pattern that the code verifier and code challenge in the PKCE flow should match according to the PKCE RFC
+ * https://www.rfc-editor.org/rfc/rfc7636
+ */
+export const codeVerifierAndChallengePattern = /^[A-Za-z\d\-._~]{43,128}$/

--- a/test/SgidClient.spec.ts
+++ b/test/SgidClient.spec.ts
@@ -1,13 +1,18 @@
 import { readFileSync } from 'fs'
 
-import SgidClient from '../src'
+import SgidClient, {
+  DEFAULT_SCOPE,
+  DEFAULT_SGID_CODE_CHALLENGE_METHOD,
+} from '../src'
 import { codeVerifierAndChallengePattern } from '../src/util'
 
 import {
   MOCK_ACCESS_TOKEN,
   MOCK_API_VERSION,
+  MOCK_API_VERSION_V2,
   MOCK_AUTH_CODE,
   MOCK_AUTH_ENDPOINT,
+  MOCK_AUTH_ENDPOINT_V2,
   MOCK_CLIENT_ID,
   MOCK_CLIENT_PRIVATE_KEY,
   MOCK_CLIENT_SECRET,
@@ -26,7 +31,6 @@ import {
 } from './mocks/handlers'
 import { server } from './mocks/server'
 
-const DEFAULT_SCOPE = 'myinfo.nric_number openid'
 const DEFAULT_RESPONSE_TYPE = 'code'
 
 describe('SgidClient', () => {
@@ -66,7 +70,8 @@ describe('SgidClient', () => {
     })
   })
 
-  describe('authorizationUrl', () => {
+  // TODO: Refactor into its own test file
+  describe('authorizationUrl (v1)', () => {
     it('should generate authorisation URL correctly when only state is provided', () => {
       const mockState = 'mockState'
 
@@ -248,6 +253,311 @@ describe('SgidClient', () => {
     })
   })
 
+  // TODO: Refactor into its own test file
+  describe('authorizationUrl (v2 with PKCE)', () => {
+    let v2Client: SgidClient
+
+    beforeAll(() => {
+      v2Client = new SgidClient({
+        clientId: MOCK_CLIENT_ID,
+        clientSecret: MOCK_CLIENT_SECRET,
+        privateKey: MOCK_CLIENT_PRIVATE_KEY,
+        redirectUri: MOCK_REDIRECT_URI,
+        hostname: MOCK_HOSTNAME,
+        apiVersion: MOCK_API_VERSION_V2,
+      })
+    })
+
+    it('should generate authorisation URL correctly when state and codeChallenge is provided', () => {
+      const mockState = 'mockState'
+      const mockCodeChallenge = 'mockCodeChallenge'
+
+      const { url, nonce } = v2Client.authorizationUrl(
+        mockState,
+        undefined,
+        undefined,
+        undefined,
+        mockCodeChallenge,
+        undefined,
+      )
+
+      const actual = new URL(url)
+      // Count number of search params
+      let actualNumSearchParams = 0
+      actual.searchParams.forEach(() => actualNumSearchParams++)
+      const expected = new URL(MOCK_AUTH_ENDPOINT_V2)
+      expect(actual.host).toBe(expected.host)
+      expect(actual.pathname).toBe(expected.pathname)
+      expect(actual.searchParams.get('client_id')).toBe(MOCK_CLIENT_ID)
+      expect(actual.searchParams.get('scope')).toBe(DEFAULT_SCOPE)
+      expect(actual.searchParams.get('response_type')).toBe(
+        DEFAULT_RESPONSE_TYPE,
+      )
+      expect(actual.searchParams.get('redirect_uri')).toBe(MOCK_REDIRECT_URI)
+      expect(actual.searchParams.get('nonce')).toBe(nonce)
+      expect(actual.searchParams.get('state')).toBe(mockState)
+      expect(actual.searchParams.get('code_challenge')).toBe(mockCodeChallenge)
+      expect(actual.searchParams.get('code_challenge_method')).toBe(
+        DEFAULT_SGID_CODE_CHALLENGE_METHOD,
+      )
+      // Client ID, scope, response_type, redirect_uri, nonce, state, code_challenge, code_challenge_method
+      expect(actualNumSearchParams).toBe(8)
+    })
+
+    it('should generate authorisation URL correctly when state, codeChallenge, and codeChallengeMethod is provided', () => {
+      const mockState = 'mockState'
+      const mockCodeChallenge = 'mockCodeChallenge'
+      const mockCodeChallengeMethod = 'plain'
+
+      const { url, nonce } = v2Client.authorizationUrl(
+        mockState,
+        undefined,
+        undefined,
+        undefined,
+        mockCodeChallenge,
+        mockCodeChallengeMethod,
+      )
+
+      const actual = new URL(url)
+      // Count number of search params
+      let actualNumSearchParams = 0
+      actual.searchParams.forEach(() => actualNumSearchParams++)
+      const expected = new URL(MOCK_AUTH_ENDPOINT_V2)
+      expect(actual.host).toBe(expected.host)
+      expect(actual.pathname).toBe(expected.pathname)
+      expect(actual.searchParams.get('client_id')).toBe(MOCK_CLIENT_ID)
+      expect(actual.searchParams.get('scope')).toBe(DEFAULT_SCOPE)
+      expect(actual.searchParams.get('response_type')).toBe(
+        DEFAULT_RESPONSE_TYPE,
+      )
+      expect(actual.searchParams.get('redirect_uri')).toBe(MOCK_REDIRECT_URI)
+      expect(actual.searchParams.get('nonce')).toBe(nonce)
+      expect(actual.searchParams.get('state')).toBe(mockState)
+      expect(actual.searchParams.get('code_challenge')).toBe(mockCodeChallenge)
+      // Important check is here
+      expect(actual.searchParams.get('code_challenge_method')).toBe(
+        mockCodeChallengeMethod,
+      )
+      // Client ID, scope, response_type, redirect_uri, nonce, state, code_challenge, code_challenge_method
+      expect(actualNumSearchParams).toBe(8)
+    })
+
+    it('should generate authorisation URL correctly when state, codeChallenge, and scope is provided as a string', () => {
+      const mockState = 'mockState'
+      const mockScope = 'mockScope'
+      const mockCodeChallenge = 'mockCodeChallenge'
+
+      const { url, nonce } = v2Client.authorizationUrl(
+        mockState,
+        mockScope,
+        undefined,
+        undefined,
+        mockCodeChallenge,
+        undefined,
+      )
+
+      const actual = new URL(url)
+      // Count number of search params
+      let actualNumSearchParams = 0
+      actual.searchParams.forEach(() => actualNumSearchParams++)
+      const expected = new URL(MOCK_AUTH_ENDPOINT_V2)
+      expect(actual.host).toBe(expected.host)
+      expect(actual.pathname).toBe(expected.pathname)
+      expect(actual.searchParams.get('client_id')).toBe(MOCK_CLIENT_ID)
+      // Important check is here
+      expect(actual.searchParams.get('scope')).toBe(mockScope)
+      expect(actual.searchParams.get('response_type')).toBe(
+        DEFAULT_RESPONSE_TYPE,
+      )
+      expect(actual.searchParams.get('redirect_uri')).toBe(MOCK_REDIRECT_URI)
+      expect(actual.searchParams.get('nonce')).toBe(nonce)
+      expect(actual.searchParams.get('state')).toBe(mockState)
+      expect(actual.searchParams.get('code_challenge')).toBe(mockCodeChallenge)
+      expect(actual.searchParams.get('code_challenge_method')).toBe(
+        DEFAULT_SGID_CODE_CHALLENGE_METHOD,
+      )
+      // Client ID, scope, response_type, redirect_uri, nonce, state, code_challenge, code_challenge_method
+      expect(actualNumSearchParams).toBe(8)
+    })
+
+    it('should generate authorisation URL correctly when state, codeChallenge, and scope is provided as a string array', () => {
+      const mockState = 'mockState'
+      const mockScopes = ['mockScope1', 'mockScope2', 'mockScope3']
+      const mockCodeChallenge = 'mockCodeChallenge'
+
+      const { url, nonce } = v2Client.authorizationUrl(
+        mockState,
+        mockScopes,
+        undefined,
+        undefined,
+        mockCodeChallenge,
+        undefined,
+      )
+
+      const actual = new URL(url)
+      // Count number of search params
+      let actualNumSearchParams = 0
+      actual.searchParams.forEach(() => actualNumSearchParams++)
+      const expected = new URL(MOCK_AUTH_ENDPOINT_V2)
+      expect(actual.host).toBe(expected.host)
+      expect(actual.pathname).toBe(expected.pathname)
+      expect(actual.searchParams.get('client_id')).toBe(MOCK_CLIENT_ID)
+      // Important check is here
+      expect(actual.searchParams.get('scope')).toBe(mockScopes.join(' '))
+      expect(actual.searchParams.get('response_type')).toBe(
+        DEFAULT_RESPONSE_TYPE,
+      )
+      expect(actual.searchParams.get('redirect_uri')).toBe(MOCK_REDIRECT_URI)
+      expect(actual.searchParams.get('nonce')).toBe(nonce)
+      expect(actual.searchParams.get('state')).toBe(mockState)
+      expect(actual.searchParams.get('code_challenge')).toBe(mockCodeChallenge)
+      expect(actual.searchParams.get('code_challenge_method')).toBe(
+        DEFAULT_SGID_CODE_CHALLENGE_METHOD,
+      )
+      // Client ID, scope, response_type, redirect_uri, nonce, state, code_challenge, code_challenge_method
+      expect(actualNumSearchParams).toBe(8)
+    })
+
+    it('should generate authorisation URL correctly when state, codeChallenge, and nonce is specified', () => {
+      const mockState = 'mockState'
+      const mockNonce = 'mockNonce'
+      const mockCodeChallenge = 'mockCodeChallenge'
+
+      const { url, nonce } = v2Client.authorizationUrl(
+        mockState,
+        undefined,
+        mockNonce,
+        undefined,
+        mockCodeChallenge,
+        undefined,
+      )
+
+      const actual = new URL(url)
+      // Count number of search params
+      let actualNumSearchParams = 0
+      actual.searchParams.forEach(() => actualNumSearchParams++)
+      const expected = new URL(MOCK_AUTH_ENDPOINT_V2)
+      expect(actual.host).toBe(expected.host)
+      expect(actual.pathname).toBe(expected.pathname)
+      expect(actual.searchParams.get('client_id')).toBe(MOCK_CLIENT_ID)
+      expect(actual.searchParams.get('scope')).toBe(DEFAULT_SCOPE)
+      expect(actual.searchParams.get('response_type')).toBe(
+        DEFAULT_RESPONSE_TYPE,
+      )
+      expect(actual.searchParams.get('redirect_uri')).toBe(MOCK_REDIRECT_URI)
+      // Important check is here
+      expect(actual.searchParams.get('nonce')).toBe(mockNonce)
+      expect(nonce).toBe(mockNonce)
+      expect(actual.searchParams.get('state')).toBe(mockState)
+      expect(actual.searchParams.get('code_challenge')).toBe(mockCodeChallenge)
+      expect(actual.searchParams.get('code_challenge_method')).toBe(
+        DEFAULT_SGID_CODE_CHALLENGE_METHOD,
+      )
+      // Client ID, scope, response_type, redirect_uri, nonce, state, code_challenge, code_challenge_method
+      expect(actualNumSearchParams).toBe(8)
+    })
+
+    it('should generate authorisation URL correctly when state and codeChallenge is provided and nonce is null', () => {
+      const mockState = 'mockState'
+      const mockCodeChallenge = 'mockCodeChallenge'
+
+      const { url, nonce } = v2Client.authorizationUrl(
+        mockState,
+        undefined,
+        null,
+        undefined,
+        mockCodeChallenge,
+        undefined,
+      )
+
+      const actual = new URL(url)
+      // Count number of search params
+      let actualNumSearchParams = 0
+      actual.searchParams.forEach(() => actualNumSearchParams++)
+      const expected = new URL(MOCK_AUTH_ENDPOINT_V2)
+      expect(actual.host).toBe(expected.host)
+      expect(actual.pathname).toBe(expected.pathname)
+      expect(actual.searchParams.get('client_id')).toBe(MOCK_CLIENT_ID)
+      expect(actual.searchParams.get('scope')).toBe(DEFAULT_SCOPE)
+      expect(actual.searchParams.get('response_type')).toBe(
+        DEFAULT_RESPONSE_TYPE,
+      )
+      expect(actual.searchParams.get('redirect_uri')).toBe(MOCK_REDIRECT_URI)
+      // Important check is here
+      expect(actual.searchParams.get('nonce')).toBeNull()
+      expect(nonce).toBeUndefined()
+      expect(actual.searchParams.get('state')).toBe(mockState)
+      expect(actual.searchParams.get('code_challenge')).toBe(mockCodeChallenge)
+      expect(actual.searchParams.get('code_challenge_method')).toBe(
+        DEFAULT_SGID_CODE_CHALLENGE_METHOD,
+      )
+      // Client ID, scope, response_type, redirect_uri, state, code_challenge, code_challenge_method
+      expect(actualNumSearchParams).toBe(7)
+    })
+
+    it('should generate authorisation URL correctly when state, codeChallenge, and redirectUri is provided', () => {
+      const mockState = 'mockState'
+      const mockRedirectUri = 'https://mockRedirectUri.com'
+      const mockCodeChallenge = 'mockCodeChallenge'
+
+      const { url, nonce } = v2Client.authorizationUrl(
+        mockState,
+        undefined,
+        undefined,
+        mockRedirectUri,
+        mockCodeChallenge,
+        undefined,
+      )
+
+      const actual = new URL(url)
+      // Count number of search params
+      let actualNumSearchParams = 0
+      actual.searchParams.forEach(() => actualNumSearchParams++)
+      const expected = new URL(MOCK_AUTH_ENDPOINT_V2)
+      expect(actual.host).toBe(expected.host)
+      expect(actual.pathname).toBe(expected.pathname)
+      expect(actual.searchParams.get('client_id')).toBe(MOCK_CLIENT_ID)
+      expect(actual.searchParams.get('scope')).toBe(DEFAULT_SCOPE)
+      expect(actual.searchParams.get('response_type')).toBe(
+        DEFAULT_RESPONSE_TYPE,
+      )
+      // Important check is here
+      expect(actual.searchParams.get('redirect_uri')).toBe(mockRedirectUri)
+      expect(actual.searchParams.get('nonce')).toBe(nonce)
+      expect(actual.searchParams.get('state')).toBe(mockState)
+      expect(actual.searchParams.get('code_challenge')).toBe(mockCodeChallenge)
+      expect(actual.searchParams.get('code_challenge_method')).toBe(
+        DEFAULT_SGID_CODE_CHALLENGE_METHOD,
+      )
+      // Client ID, scope, response_type, redirect_uri, nonce, state, code_challenge, code_challenge_method
+      expect(actualNumSearchParams).toBe(8)
+    })
+
+    it('should throw when no redirectUri is provided', () => {
+      const mockState = 'mockState'
+      const mockCodeChallenge = 'mockCodeChallenge'
+
+      const noRedirectUriClient = new SgidClient({
+        clientId: MOCK_CLIENT_ID,
+        clientSecret: MOCK_CLIENT_SECRET,
+        privateKey: MOCK_CLIENT_PRIVATE_KEY,
+        hostname: MOCK_HOSTNAME,
+        apiVersion: MOCK_API_VERSION_V2,
+      })
+
+      expect(() =>
+        noRedirectUriClient.authorizationUrl(
+          mockState,
+          undefined,
+          undefined,
+          undefined,
+          mockCodeChallenge,
+          undefined,
+        ),
+      ).toThrow('No redirect URI registered with this client')
+    })
+  })
+
   describe('callback', () => {
     it('should call token endpoint and return sub and accessToken', async () => {
       const { sub, accessToken } = await client.callback(MOCK_AUTH_CODE)
@@ -358,18 +668,18 @@ describe('SgidClient', () => {
 
   describe('codeChallenge', () => {
     it('should match the specified pattern', () => {
-      const MOCK_CODE_VERIFIER = 'bbGcObXZC1YGBQZZtZGQH9jsyO1vypqCGqnSU_4TI5S'
+      const mockCodeVerifier = 'bbGcObXZC1YGBQZZtZGQH9jsyO1vypqCGqnSU_4TI5S'
 
-      expect(client.codeChallenge(MOCK_CODE_VERIFIER)).toMatch(
+      expect(client.codeChallenge(mockCodeVerifier)).toMatch(
         codeVerifierAndChallengePattern,
       )
     })
 
     it('should be deterministic (return the same code challenge given the same code verifier)', () => {
-      const MOCK_CODE_VERIFIER = 'bbGcObXZC1YGBQZZtZGQH9jsyO1vypqCGqnSU_4TI5S'
+      const mockCodeVerifier = 'bbGcObXZC1YGBQZZtZGQH9jsyO1vypqCGqnSU_4TI5S'
 
-      const firstCodeChallenge = client.codeChallenge(MOCK_CODE_VERIFIER)
-      const secondCodeChallenge = client.codeChallenge(MOCK_CODE_VERIFIER)
+      const firstCodeChallenge = client.codeChallenge(mockCodeVerifier)
+      const secondCodeChallenge = client.codeChallenge(mockCodeVerifier)
 
       expect(firstCodeChallenge).toBe(secondCodeChallenge)
     })

--- a/test/mocks/constants.ts
+++ b/test/mocks/constants.ts
@@ -8,10 +8,16 @@ export const MOCK_PRIVATE_KEY = readFileSync(
   `${__dirname}/mockPrivateKey.pem`,
 ).toString()
 export const MOCK_HOSTNAME = 'https://id.sgid.com'
-export const MOCK_API_VERSION = 3
+// apiVersion 1
+export const MOCK_API_VERSION = 1
 export const MOCK_AUTH_ENDPOINT = `${MOCK_HOSTNAME}/v${MOCK_API_VERSION}/oauth/authorize`
 export const MOCK_TOKEN_ENDPOINT = `${MOCK_HOSTNAME}/v${MOCK_API_VERSION}/oauth/token`
 export const MOCK_USERINFO_ENDPOINT = `${MOCK_HOSTNAME}/v${MOCK_API_VERSION}/oauth/userinfo`
+// apiVersion 2
+export const MOCK_API_VERSION_V2 = 2
+export const MOCK_AUTH_ENDPOINT_V2 = `${MOCK_HOSTNAME}/v${MOCK_API_VERSION_V2}/oauth/authorize`
+export const MOCK_TOKEN_ENDPOINT_V2 = `${MOCK_HOSTNAME}/v${MOCK_API_VERSION_V2}/oauth/token`
+export const MOCK_USERINFO_ENDPOINT_V2 = `${MOCK_HOSTNAME}/v${MOCK_API_VERSION_V2}/oauth/userinfo`
 export const MOCK_JWKS_ENDPOINT = `${
   new URL(MOCK_HOSTNAME).origin
 }/.well-known/jwks.json`


### PR DESCRIPTION
## Problem

_What problem are you trying to solve? What issue does this close?_

Closes [insert issue #]

## Solution

_How did you solve the problem?_

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Concerns
1. ESLint is throwing the error `Synchronous methods should return an instance of Error instead of throwing  typesafe/no-throw-sync-func`. However, in the function `getFirstRedirectUri()`, the error is being ignored. Is this
    1. something we want and should we return errors instead of throwing them?
    2. Or should we remove ignore this rule by editing the `.eslintrc`?

2. `codeVerifier` function is implemented by using the `openid-client` library's `generators.codeVerifier` function to generate 96 bytes (128 base64-encoded characters) and then slicing the first N number of characters. 
    - This was done because having the user input `length` instead of `bytes` is more easily understandable and more directly related to the length constraint
    - i.e. it is clearer that 43 and 128 characters are the boundaries - but it is not as easily understood why 32 bytes is within the boundary but 31 bytes is not
    - And there is no clear conversion from `length` in characters to `bytes` to be passed into the `generators.codeVerifier` function due to extra padding during base64 url encoding
    - The more important question is: **Is slicing the first N number of characters still secure?**
    
3. Should we refactor `authorizationUrl` into its own file? As the new private helper functions `authorizationUrlV1` and `authorizationUrlV2` have been created, the `index.ts` file length has been getting longer and thus less readable (Same for the tests)

## Before & After Screenshots

**BEFORE**:
[insert screenshot here]

**AFTER**:
[insert screenshot here]

## Tests

_What tests should be run to confirm functionality?_

## Deploy Notes

_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc._

**New environment variables**:

- `env var` : env var details

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details

