### PR TITLE
feat: PKCE code verifier

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -194,6 +194,26 @@ export class SgidClient {
     }
     return result
   }
+
+  /**
+   * Generates the code verifier (random bytes encoded in url safe base 64) to be used in the OAuth 2.0 PKCE flow
+   * @param length The length of the code verifier to generate (Defaults to 43 if not provided)
+   * @returns The generated code verifier
+   */
+  codeVerifier(length = 43): string {
+    if (length < 43 || length > 128) {
+      // eslint-disable-next-line typesafe/no-throw-sync-func
+      throw new Error(
+        `The code verifier should have a minimum length of 43 and a maximum length of 128. Length of ${length} was provided`,
+      )
+    }
+
+    // 96 bytes results in a 128 long base64 string
+    const codeVerifier = generators.codeVerifier(96)
+
+    // This works because a prefix of a random string is still random
+    return codeVerifier.slice(0, length)
+  }
 }
 
 export default SgidClient

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,3 +7,9 @@ export function convertPkcs1ToPkcs8(pkcs1: string): string {
   const key = new NodeRSA(pkcs1, 'pkcs1')
   return key.exportKey('pkcs8')
 }
+
+/**
+ * Regex pattern that the code verifier and code challenge in the PKCE flow should match according to the PKCE RFC
+ * https://www.rfc-editor.org/rfc/rfc7636
+ */
+export const codeVerifierAndChallengePattern = /^[A-Za-z\d\-._~]{43,128}$/

--- a/test/SgidClient.spec.ts
+++ b/test/SgidClient.spec.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'fs'
 
 import SgidClient from '../src'
+import { codeVerifierAndChallengePattern } from '../src/util'
 
 import {
   MOCK_ACCESS_TOKEN,
@@ -327,6 +328,31 @@ describe('SgidClient', () => {
       await expect(client.userinfo(MOCK_ACCESS_TOKEN)).rejects.toThrow(
         'Unable to decrypt payload',
       )
+    })
+  })
+
+  describe('codeVerifier', () => {
+    it('should generate a code verifier of length 43 when no length is provided', () => {
+      const codeVerifier = client.codeVerifier()
+
+      expect(codeVerifier.length).toBe(43)
+      expect(codeVerifier).toMatch(codeVerifierAndChallengePattern)
+    })
+
+    it('should generate a code verifier of specified length when length between 43 (inclusive) and 128 (inclusive) is provided', () => {
+      for (let length = 43; length <= 128; length++) {
+        const codeVerifier = client.codeVerifier(length)
+        expect(codeVerifier.length).toBe(length)
+        expect(codeVerifier).toMatch(codeVerifierAndChallengePattern)
+      }
+    })
+
+    it('should throw an error when a length < 43 or length > 128 is provided', () => {
+      for (const length of [-1, 0, 42, 129, 138, 999]) {
+        expect(() => client.codeVerifier(length)).toThrowError(
+          `The code verifier should have a minimum length of 43 and a maximum length of 128. Length of ${length} was provided`,
+        )
+      }
     })
   })
 })


### PR DESCRIPTION
## Problem

Adds the `codeVerifier` function to generate a code verifier for the [PKCE flow](https://github.com/datagovsg/sgid-server/issues/244).

## Concerns 
1. ESLint is throwing the error `Synchronous methods should return an instance of Error instead of throwing  typesafe/no-throw-sync-func`. However, in the function `getFirstRedirectUri()`, the error is being ignored. Is this
    1. something we want and should we return errors instead of throwing them?
    2. Or should we remove ignore this rule by editing the `.eslintrc`?

2. `codeVerifier` function is implemented by using the `openid-client` library's `generators.codeVerifier` function to generate 96 bytes (128 base64-encoded characters) and then slicing the first N number of characters. 
    - This was done because having the user input `length` instead of `bytes` is more easily understandable and more directly related to the length constraint
    - i.e. it is clearer that 43 and 128 characters are the boundaries - but it is not as easily understood why 32 bytes is within the boundary but 31 bytes is not
    - And there is no clear conversion from `length` in characters to `bytes` to be passed into the `generators.codeVerifier` function due to extra padding during base64 url encoding
    - The more important question is: **Is slicing the first N number of characters still secure?**

## Tests

Tests were added in `SgidClient.spec.ts`

Test strategy outline can be found [here](https://www.notion.so/opengov/PKCE-sgid-client-Test-Strategy-a5ad8816c7ca4bbaaa4e5b5f6e199526?pvs=4) 


