### PR TITLE
feat: PKCE `codeVerifier` and `codeChallenge` (Option 1.1)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -196,6 +196,21 @@ export class SgidClient {
   }
 
   /**
+   * Generates a PKCE challenge pair where `codeChallenge` is the generated S256 challenge from `codeVerifier`
+   * @param length The length of the code verifier
+   * @returns The generated challenge pair
+   */
+  generatePkcePair(length = 43): {
+    codeVerifier: string
+    codeChallenge: string
+  } {
+    const codeVerifier = this.generateCodeVerifier(length)
+    const codeChallenge = this.generateCodeChallenge(codeVerifier)
+
+    return { codeVerifier, codeChallenge }
+  }
+
+  /**
    * Generates the code verifier (random bytes encoded in url safe base 64) to be used in the OAuth 2.0 PKCE flow
    * @param length The length of the code verifier to generate (Defaults to 43 if not provided)
    * @returns The generated code verifier

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,7 +200,7 @@ export class SgidClient {
    * @param length The length of the code verifier to generate (Defaults to 43 if not provided)
    * @returns The generated code verifier
    */
-  codeVerifier(length = 43): string {
+  generateCodeVerifier(length = 43): string {
     if (length < 43 || length > 128) {
       // eslint-disable-next-line typesafe/no-throw-sync-func
       throw new Error(
@@ -220,7 +220,7 @@ export class SgidClient {
    * @param codeVerifier The code verifier to calculate the S256 code challenge for
    * @returns The calculated code challenge
    */
-  codeChallenge(codeVerifier: string): string {
+  generateCodeChallenge(codeVerifier: string): string {
     return generators.codeChallenge(codeVerifier)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,6 +194,26 @@ export class SgidClient {
     }
     return result
   }
+
+  /**
+   * Generates the code verifier (random bytes encoded in url safe base 64) to be used in the OAuth 2.0 PKCE flow
+   * @param length The length of the code verifier to generate (Defaults to 43 if not provided)
+   * @returns The generated code verifier
+   */
+  codeVerifier(length = 43): string {
+    if (length < 43 || length > 128) {
+      // eslint-disable-next-line typesafe/no-throw-sync-func
+      throw new Error(
+        `The code verifier should have a minimum length of 43 and a maximum length of 128. Length of ${length} was provided`,
+      )
+    }
+
+    // 96 bytes results in a 128 long base64 string
+    const codeVerifier = generators.codeVerifier(96)
+
+    // This works because a prefix of a random string is still random
+    return codeVerifier.slice(0, length)
+  }
 }
 
 export default SgidClient

--- a/src/index.ts
+++ b/src/index.ts
@@ -214,6 +214,15 @@ export class SgidClient {
     // This works because a prefix of a random string is still random
     return codeVerifier.slice(0, length)
   }
+
+  /**
+   * Calculates the S256 PKCE code challenge for a provided code verifier
+   * @param codeVerifier The code verifier to calculate the S256 code challenge for
+   * @returns The calculated code challenge
+   */
+  codeChallenge(codeVerifier: string): string {
+    return generators.codeChallenge(codeVerifier)
+  }
 }
 
 export default SgidClient

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,3 +7,9 @@ export function convertPkcs1ToPkcs8(pkcs1: string): string {
   const key = new NodeRSA(pkcs1, 'pkcs1')
   return key.exportKey('pkcs8')
 }
+
+/**
+ * Regex pattern that the code verifier and code challenge in the PKCE flow should match according to the PKCE RFC
+ * https://www.rfc-editor.org/rfc/rfc7636
+ */
+export const codeVerifierAndChallengePattern = /^[A-Za-z\d\-._~]{43,128}$/

--- a/test/SgidClient.spec.ts
+++ b/test/SgidClient.spec.ts
@@ -355,4 +355,23 @@ describe('SgidClient', () => {
       }
     })
   })
+
+  describe('codeChallenge', () => {
+    it('should match the specified pattern', () => {
+      const mockCodeVerifier = 'bbGcObXZC1YGBQZZtZGQH9jsyO1vypqCGqnSU_4TI5S'
+
+      expect(client.codeChallenge(mockCodeVerifier)).toMatch(
+        codeVerifierAndChallengePattern,
+      )
+    })
+
+    it('should be deterministic (return the same code challenge given the same code verifier)', () => {
+      const mockCodeVerifier = 'bbGcObXZC1YGBQZZtZGQH9jsyO1vypqCGqnSU_4TI5S'
+
+      const firstCodeChallenge = client.codeChallenge(mockCodeVerifier)
+      const secondCodeChallenge = client.codeChallenge(mockCodeVerifier)
+
+      expect(firstCodeChallenge).toBe(secondCodeChallenge)
+    })
+  })
 })

--- a/test/SgidClient.spec.ts
+++ b/test/SgidClient.spec.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'fs'
 
 import SgidClient from '../src'
+import { codeVerifierAndChallengePattern } from '../src/util'
 
 import {
   MOCK_ACCESS_TOKEN,
@@ -327,6 +328,31 @@ describe('SgidClient', () => {
       await expect(client.userinfo(MOCK_ACCESS_TOKEN)).rejects.toThrow(
         'Unable to decrypt payload',
       )
+    })
+  })
+
+  describe('codeVerifier', () => {
+    it('should generate a code verifier of length 43 when no length is provided', () => {
+      const codeVerifier = client.codeVerifier()
+
+      expect(codeVerifier.length).toBe(43)
+      expect(codeVerifier).toMatch(codeVerifierAndChallengePattern)
+    })
+
+    it('should generate a code verifier of specified length when length between 43 (inclusive) and 128 (inclusive) is provided', () => {
+      for (let length = 43; length <= 128; length++) {
+        const codeVerifier = client.codeVerifier(length)
+        expect(codeVerifier.length).toBe(length)
+        expect(codeVerifier).toMatch(codeVerifierAndChallengePattern)
+      }
+    })
+
+    it('should throw an error when a length < 43 or length > 128 is provided', () => {
+      for (const length of [-1, 0, 42, 129, 138, 999]) {
+        expect(() => client.codeVerifier(length)).toThrowError(
+          `The code verifier should have a minimum length of 43 and a maximum length of 128. Length of ${length} was provided`,
+        )
+      }
     })
   })
 })

--- a/test/SgidClient.spec.ts
+++ b/test/SgidClient.spec.ts
@@ -331,6 +331,13 @@ describe('SgidClient', () => {
     })
   })
 
+  describe('generatePkcePair', () => {
+    it('can generate a PKCE pair', () => {
+      const pkcePair = client.generatePkcePair()
+      expect(pkcePair).toBeDefined()
+    })
+  })
+
   describe('generateCodeVerifier', () => {
     it('should generate a code verifier of length 43 when no length is provided', () => {
       const codeVerifier = client.generateCodeVerifier()

--- a/test/SgidClient.spec.ts
+++ b/test/SgidClient.spec.ts
@@ -331,9 +331,9 @@ describe('SgidClient', () => {
     })
   })
 
-  describe('codeVerifier', () => {
+  describe('generateCodeVerifier', () => {
     it('should generate a code verifier of length 43 when no length is provided', () => {
-      const codeVerifier = client.codeVerifier()
+      const codeVerifier = client.generateCodeVerifier()
 
       expect(codeVerifier.length).toBe(43)
       expect(codeVerifier).toMatch(codeVerifierAndChallengePattern)
@@ -341,7 +341,7 @@ describe('SgidClient', () => {
 
     it('should generate a code verifier of specified length when length between 43 (inclusive) and 128 (inclusive) is provided', () => {
       for (let length = 43; length <= 128; length++) {
-        const codeVerifier = client.codeVerifier(length)
+        const codeVerifier = client.generateCodeVerifier(length)
         expect(codeVerifier.length).toBe(length)
         expect(codeVerifier).toMatch(codeVerifierAndChallengePattern)
       }
@@ -349,18 +349,18 @@ describe('SgidClient', () => {
 
     it('should throw an error when a length < 43 or length > 128 is provided', () => {
       for (const length of [-1, 0, 42, 129, 138, 999]) {
-        expect(() => client.codeVerifier(length)).toThrowError(
+        expect(() => client.generateCodeVerifier(length)).toThrowError(
           `The code verifier should have a minimum length of 43 and a maximum length of 128. Length of ${length} was provided`,
         )
       }
     })
   })
 
-  describe('codeChallenge', () => {
+  describe('generateCodeChallenge', () => {
     it('should match the specified pattern', () => {
       const mockCodeVerifier = 'bbGcObXZC1YGBQZZtZGQH9jsyO1vypqCGqnSU_4TI5S'
 
-      expect(client.codeChallenge(mockCodeVerifier)).toMatch(
+      expect(client.generateCodeChallenge(mockCodeVerifier)).toMatch(
         codeVerifierAndChallengePattern,
       )
     })
@@ -368,8 +368,8 @@ describe('SgidClient', () => {
     it('should be deterministic (return the same code challenge given the same code verifier)', () => {
       const mockCodeVerifier = 'bbGcObXZC1YGBQZZtZGQH9jsyO1vypqCGqnSU_4TI5S'
 
-      const firstCodeChallenge = client.codeChallenge(mockCodeVerifier)
-      const secondCodeChallenge = client.codeChallenge(mockCodeVerifier)
+      const firstCodeChallenge = client.generateCodeChallenge(mockCodeVerifier)
+      const secondCodeChallenge = client.generateCodeChallenge(mockCodeVerifier)
 
       expect(firstCodeChallenge).toBe(secondCodeChallenge)
     })


### PR DESCRIPTION
## Problem

Supporting the [[Proof Key for Code Exchange (PKCE)](https://www.rfc-editor.org/rfc/rfc7636)](https://www.rfc-editor.org/rfc/rfc7636) extension to OAuth 2.0 is a current best practice for preventing authorisation code interception attacks in native apps. As per [[RFC 8252 (OAuth 2.0 for Native Apps)](https://www.rfc-editor.org/rfc/rfc8252)]:

> Public native app clients MUST implement the Proof Key for Code Exchange (PKCE [RFC7636]) extension to OAuth, and authorization servers MUST support PKCE for such clients, for the reasons detailed in Section 8.1.
> 

Since it prevents auth code injection attacks, it is useful for client types other than native apps as well.

This PR is linked to this [issue](https://github.com/datagovsg/sgid-server/issues/244)

## Solution

This is PR **1** of 3 for [Option 1](https://www.notion.so/opengov/PKCE-sgid-client-breaking-changes-6e2854240f75496f89335d69f709acff?pvs=4)

PR 2 of 3 (#33)
PR 3 of 3 (#34)

**Features**:

Adds the `codeVerifier` and `codeChallenge` function to generate a code challenge for the [PKCE flow](https://github.com/datagovsg/sgid-server/issues/244).

`codeChallenge` is a wrapper over `openid-client` [`generators.codeChallenge`](https://github.com/panva/node-openid-client/blob/main/docs/README.md#generatorscodechallengeverifier)


## Concerns 
1. ESLint is throwing the error `Synchronous methods should return an instance of Error instead of throwing  typesafe/no-throw-sync-func`. However, in the function `getFirstRedirectUri()`, the error is being ignored. Is this
    1. something we want and should we return errors instead of throwing them?
    2. Or should we remove ignore this rule by editing the `.eslintrc`?

2. `codeVerifier` function is implemented by using the `openid-client` library's `generators.codeVerifier` function to generate 96 bytes (128 base64-encoded characters) and then slicing the first N number of characters. 
    - This was done because having the user input `length` instead of `bytes` is more easily understandable and more directly related to the length constraint
    - i.e. it is clearer that 43 and 128 characters are the boundaries - but it is not as easily understood why 32 bytes is within the boundary but 31 bytes is not
    - And there is no clear conversion from `length` in characters to `bytes` to be passed into the `generators.codeVerifier` function due to extra padding during base64 url encoding
    - The more important question is: **Is slicing the first N number of characters still secure?**

## Tests

Tests were added in `SgidClient.spec.ts`

Test strategy outline can be found [here](https://www.notion.so/opengov/PKCE-sgid-client-Test-Strategy-a5ad8816c7ca4bbaaa4e5b5f6e199526?pvs=4) 
