### PR TITLE
feat: PKCE callback function (Option 1.3)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -182,6 +182,7 @@ export class SgidClient {
    * @param code The authorization code received from the authorization server
    * @param nonce Specify null if no nonce
    * @param redirectUri The redirect URI used in the authorization request, defaults to the one registered with the client
+   * @param codeVerifier The code verifier that was used to generate the code challenge that was passed in `authorizationUrl`
    * @returns The sub of the user and access token
    */
   async callback(

--- a/src/index.ts
+++ b/src/index.ts
@@ -237,8 +237,8 @@ export class SgidClient {
 
     const tokenSet = await this.sgID.callback(
       redirectUri,
-      { code, code_verifier: codeVerifier },
-      { nonce: nonce ?? undefined },
+      { code },
+      { nonce: nonce ?? undefined, code_verifier: codeVerifier },
     )
     const { sub } = tokenSet.claims()
     const { access_token: accessToken } = tokenSet

--- a/src/index.ts
+++ b/src/index.ts
@@ -325,7 +325,7 @@ export class SgidClient {
    * @param length The length of the code verifier
    * @returns The generated challenge pair
    */
-  generatePkcePair(length = 43): {
+  static generatePkcePair(length = 43): {
     codeVerifier: string
     codeChallenge: string
   } {
@@ -340,7 +340,7 @@ export class SgidClient {
    * @param length The length of the code verifier to generate (Defaults to 43 if not provided)
    * @returns The generated code verifier
    */
-  generateCodeVerifier(length = 43): string {
+  static generateCodeVerifier(length = 43): string {
     if (length < 43 || length > 128) {
       // eslint-disable-next-line typesafe/no-throw-sync-func
       throw new Error(
@@ -360,7 +360,7 @@ export class SgidClient {
    * @param codeVerifier The code verifier to calculate the S256 code challenge for
    * @returns The calculated code challenge
    */
-  generateCodeChallenge(codeVerifier: string): string {
+  static generateCodeChallenge(codeVerifier: string): string {
     return generators.codeChallenge(codeVerifier)
   }
 }

--- a/test/SgidClient.spec.ts
+++ b/test/SgidClient.spec.ts
@@ -6,18 +6,16 @@ import { codeVerifierAndChallengePattern } from '../src/util'
 import {
   MOCK_ACCESS_TOKEN,
   MOCK_API_VERSION,
-  MOCK_AUTH_CODE,
   MOCK_CLIENT_ID,
   MOCK_CLIENT_PRIVATE_KEY,
   MOCK_CLIENT_SECRET,
+  MOCK_CODE_VERIFIER,
   MOCK_HOSTNAME,
   MOCK_REDIRECT_URI,
   MOCK_SUB,
   MOCK_USERINFO_PLAINTEXT,
 } from './mocks/constants'
 import {
-  tokenHandlerNoSub,
-  tokenHandlerNoToken,
   userInfoHandlerMalformedData,
   userInfoHandlerMalformedKey,
   userInfoHandlerNoData,
@@ -59,31 +57,6 @@ describe('SgidClient', () => {
       })
 
       expect(pkcs8Client).toBeDefined()
-    })
-  })
-
-  describe('callback', () => {
-    it('should call token endpoint and return sub and accessToken', async () => {
-      const { sub, accessToken } = await client.callback(MOCK_AUTH_CODE)
-
-      expect(sub).toBe(MOCK_SUB)
-      expect(accessToken).toBe(MOCK_ACCESS_TOKEN)
-    })
-
-    it('should throw when no access token is returned', async () => {
-      server.use(tokenHandlerNoToken)
-
-      await expect(client.callback(MOCK_AUTH_CODE)).rejects.toThrow(
-        'Missing sub claim or access token',
-      )
-    })
-
-    it('should throw when sub is empty', async () => {
-      server.use(tokenHandlerNoSub)
-
-      await expect(client.callback(MOCK_AUTH_CODE)).rejects.toThrow(
-        'Missing sub claim or access token',
-      )
     })
   })
 
@@ -179,18 +152,16 @@ describe('SgidClient', () => {
 
   describe('generateCodeChallenge', () => {
     it('should match the specified pattern', () => {
-      const mockCodeVerifier = 'bbGcObXZC1YGBQZZtZGQH9jsyO1vypqCGqnSU_4TI5S'
-
-      expect(client.generateCodeChallenge(mockCodeVerifier)).toMatch(
+      expect(client.generateCodeChallenge(MOCK_CODE_VERIFIER)).toMatch(
         codeVerifierAndChallengePattern,
       )
     })
 
     it('should be deterministic (return the same code challenge given the same code verifier)', () => {
-      const mockCodeVerifier = 'bbGcObXZC1YGBQZZtZGQH9jsyO1vypqCGqnSU_4TI5S'
-
-      const firstCodeChallenge = client.generateCodeChallenge(mockCodeVerifier)
-      const secondCodeChallenge = client.generateCodeChallenge(mockCodeVerifier)
+      const firstCodeChallenge =
+        client.generateCodeChallenge(MOCK_CODE_VERIFIER)
+      const secondCodeChallenge =
+        client.generateCodeChallenge(MOCK_CODE_VERIFIER)
 
       expect(firstCodeChallenge).toBe(secondCodeChallenge)
     })

--- a/test/callback.spec.ts
+++ b/test/callback.spec.ts
@@ -1,0 +1,111 @@
+import SgidClient from '../src'
+
+import {
+  MOCK_ACCESS_TOKEN,
+  MOCK_API_VERSION,
+  MOCK_API_VERSION_V2,
+  MOCK_AUTH_CODE,
+  MOCK_CLIENT_ID,
+  MOCK_CLIENT_PRIVATE_KEY,
+  MOCK_CLIENT_SECRET,
+  MOCK_CODE_VERIFIER,
+  MOCK_HOSTNAME,
+  MOCK_REDIRECT_URI,
+  MOCK_SUB,
+} from './mocks/constants'
+import {
+  tokenHandlerNoSub,
+  tokenHandlerNoSubV2,
+  tokenHandlerNoToken,
+  tokenHandlerNoTokenV2,
+} from './mocks/handlers'
+import { server } from './mocks/server'
+
+describe('callback (v1)', () => {
+  let client: SgidClient
+
+  beforeAll(() => {
+    client = new SgidClient({
+      clientId: MOCK_CLIENT_ID,
+      clientSecret: MOCK_CLIENT_SECRET,
+      privateKey: MOCK_CLIENT_PRIVATE_KEY,
+      redirectUri: MOCK_REDIRECT_URI,
+      hostname: MOCK_HOSTNAME,
+      apiVersion: MOCK_API_VERSION,
+    })
+  })
+
+  it('should call token endpoint and return sub and accessToken', async () => {
+    const { sub, accessToken } = await client.callback(MOCK_AUTH_CODE)
+
+    expect(sub).toBe(MOCK_SUB)
+    expect(accessToken).toBe(MOCK_ACCESS_TOKEN)
+  })
+
+  it('should throw when no access token is returned', async () => {
+    server.use(tokenHandlerNoToken)
+
+    await expect(client.callback(MOCK_AUTH_CODE)).rejects.toThrow(
+      'Missing sub claim or access token',
+    )
+  })
+
+  it('should throw when sub is empty', async () => {
+    server.use(tokenHandlerNoSub)
+
+    await expect(client.callback(MOCK_AUTH_CODE)).rejects.toThrow(
+      'Missing sub claim or access token',
+    )
+  })
+})
+
+describe('callback (v2)', () => {
+  let client: SgidClient
+
+  beforeAll(() => {
+    client = new SgidClient({
+      clientId: MOCK_CLIENT_ID,
+      clientSecret: MOCK_CLIENT_SECRET,
+      privateKey: MOCK_CLIENT_PRIVATE_KEY,
+      redirectUri: MOCK_REDIRECT_URI,
+      hostname: MOCK_HOSTNAME,
+      apiVersion: MOCK_API_VERSION_V2,
+    })
+  })
+
+  it('should call token endpoint and return sub and accessToken', async () => {
+    const { sub, accessToken } = await client.callback(
+      MOCK_AUTH_CODE,
+      undefined,
+      undefined,
+      MOCK_CODE_VERIFIER,
+    )
+
+    expect(sub).toBe(MOCK_SUB)
+    expect(accessToken).toBe(MOCK_ACCESS_TOKEN)
+  })
+
+  it('should throw when no code verifier is provided', async () => {
+    await expect(
+      client.callback(MOCK_AUTH_CODE, undefined, undefined, undefined),
+    ).rejects.toThrow(
+      "Code verifier must be provided in 'callback' when using apiVersion 2",
+    )
+  })
+
+  it('should throw when no access token is returned', async () => {
+    server.use(tokenHandlerNoTokenV2)
+
+    await expect(
+      client.callback(MOCK_AUTH_CODE, undefined, undefined, MOCK_CODE_VERIFIER),
+    ).rejects.toThrow('Missing sub claim or access token')
+  })
+
+  it('should throw when sub is empty', async () => {
+    server.use(tokenHandlerNoSubV2)
+
+    await expect(
+      client.callback(MOCK_AUTH_CODE, undefined, undefined, MOCK_CODE_VERIFIER),
+    ).rejects.toThrow('Missing sub claim or access token')
+  })
+})

--- a/test/mocks/constants.ts
+++ b/test/mocks/constants.ts
@@ -41,3 +41,5 @@ export const MOCK_ACCESS_TOKEN = 'mockAccessToken'
 export const MOCK_USERINFO_PLAINTEXT = {
   myKey: 'myValue',
 }
+export const MOCK_CODE_VERIFIER = 'bbGcObXZC1YGBQZZtZGQH9jsyO1vypqCGqnSU_4TI5S'
+export const MOCK_CODE_CHALLENGE = 'zaqUHoBV3rnhBF2g0Gkz1qkpEZXHqi2OrPK1DqRi-Lk'


### PR DESCRIPTION
## Problem

Supporting the [[Proof Key for Code Exchange (PKCE)](https://www.rfc-editor.org/rfc/rfc7636)](https://www.rfc-editor.org/rfc/rfc7636) extension to OAuth 2.0 is a current best practice for preventing authorisation code interception attacks in native apps. As per [[RFC 8252 (OAuth 2.0 for Native Apps)](https://www.rfc-editor.org/rfc/rfc8252)](https://www.rfc-editor.org/rfc/rfc8252):

> Public native app clients MUST implement the Proof Key for Code Exchange (PKCE [RFC7636]) extension to OAuth, and authorization servers MUST support PKCE for such clients, for the reasons detailed in Section 8.1.
> 

Since it prevents auth code injection attacks, it is useful for client types other than native apps as well.

This PR is linked to this [issue](https://github.com/datagovsg/sgid-server/issues/244)

## Solution

This is PR **3** of 3 for [Option 1](https://www.notion.so/opengov/PKCE-sgid-client-breaking-changes-6e2854240f75496f89335d69f709acff?pvs=4)

PR 1 of 3 (#32)
PR 2 of 3 (#33)

**Features**:

Updates `callback` to handle the PKCE flow by accepting the `codeVerifier` parameters. 

Refactored the `callback` tests to be in its own file `callback.spec.ts` and split the v1 and v2 testing into its own test suite.

## Tests

Unit tests were written based on the existing unit tests for v1 but modified to for v2. Added an extra test to check that if `codeVerifier` is not passed to the `callback` function, an error will be thrown

Test strategy outline can be found [here](https://www.notion.so/opengov/PKCE-sgid-client-Test-Strategy-a5ad8816c7ca4bbaaa4e5b5f6e199526?pvs=4) 