### PR TITLE
feat: check that userinfo sub matches ID token

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ const { sub, accessToken } = await client.callback({
 `async client.userinfo(parameters)`
 
 - parameters: `<Object>`
+  - sub: `<string>` Sub obtained from `callback`.
   - accessToken: `<string>` Access token obtained from `callback`.
 - Returns: `<Object>`
   - sub: `<string>`Represents a unique identifer for the end-user.
@@ -113,7 +114,10 @@ const { sub, accessToken } = await client.callback({
 Example usage:
 
 ```typescript
-const { sub, data } = await client.userinfo({ accessToken: 'access_token' })
+const { sub, data } = await client.userinfo({
+  sub: 'sub',
+  accessToken: 'access_token',
+})
 // data: { myinfo.name: "JAMUS TAN" }
 ```
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -19,3 +19,5 @@ export const PRIVATE_KEY_IMPORT_ERROR =
 export const DECRYPT_BLOCK_KEY_ERROR =
   'Unable to decrypt or import payload key. Check that you used the correct private key.'
 export const DECRYPT_PAYLOAD_ERROR = 'Unable to decrypt payload'
+export const SUB_MISMATCH_ERROR =
+  'Sub returned by sgID did not match the sub passed to the userinfo method. Check that you passed the correct sub to the userinfo method.'

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export type CallbackParams = {
 export type CallbackReturn = { sub: string; accessToken: string }
 
 export type UserInfoParams = {
+  sub: string
   accessToken: string
 }
 

--- a/test/SgidClient.spec.ts
+++ b/test/SgidClient.spec.ts
@@ -25,6 +25,7 @@ import {
   tokenHandlerNoToken,
   userInfoHandlerMalformedData,
   userInfoHandlerMalformedKey,
+  userInfoHandlerMismatchedSub,
   userInfoHandlerNoData,
   userInfoHandlerNoKey,
 } from './mocks/handlers'
@@ -340,6 +341,7 @@ describe('SgidClient', () => {
   describe('userinfo', () => {
     it('should call userinfo endpoint and return sub and data', async () => {
       const { sub, data } = await client.userinfo({
+        sub: MOCK_SUB,
         accessToken: MOCK_ACCESS_TOKEN,
       })
 
@@ -351,6 +353,7 @@ describe('SgidClient', () => {
       server.use(userInfoHandlerNoKey)
 
       const { sub, data } = await client.userinfo({
+        sub: MOCK_SUB,
         accessToken: MOCK_ACCESS_TOKEN,
       })
 
@@ -358,10 +361,24 @@ describe('SgidClient', () => {
       expect(data).toEqual({})
     })
 
+    it('should throw when sub returned by server does not match ID token', async () => {
+      server.use(userInfoHandlerMismatchedSub)
+
+      await expect(
+        client.userinfo({
+          sub: MOCK_SUB,
+          accessToken: MOCK_ACCESS_TOKEN,
+        }),
+      ).rejects.toThrow(
+        'Sub returned by sgID did not match the sub passed to the userinfo method. Check that you passed the correct sub to the userinfo method.',
+      )
+    })
+
     it('should return empty data object when no data is returned', async () => {
       server.use(userInfoHandlerNoData)
 
       const { sub, data } = await client.userinfo({
+        sub: MOCK_SUB,
         accessToken: MOCK_ACCESS_TOKEN,
       })
 
@@ -380,6 +397,7 @@ describe('SgidClient', () => {
 
       await expect(
         invalidPrivateKeyClient.userinfo({
+          sub: MOCK_SUB,
           accessToken: MOCK_ACCESS_TOKEN,
         }),
       ).rejects.toThrow('Failed to import private key')
@@ -390,6 +408,7 @@ describe('SgidClient', () => {
 
       await expect(
         client.userinfo({
+          sub: MOCK_SUB,
           accessToken: MOCK_ACCESS_TOKEN,
         }),
       ).rejects.toThrow('Unable to decrypt or import payload key')
@@ -400,6 +419,7 @@ describe('SgidClient', () => {
 
       await expect(
         client.userinfo({
+          sub: MOCK_SUB,
           accessToken: MOCK_ACCESS_TOKEN,
         }),
       ).rejects.toThrow('Unable to decrypt payload')

--- a/test/mocks/handlers.ts
+++ b/test/mocks/handlers.ts
@@ -107,6 +107,25 @@ const userInfoHandler = rest.get(
 )
 
 /**
+ * Handler to test case where userinfo endpoint returns a sub
+ * which is different from the sub previously returned in the
+ * ID token from the callback endpoint
+ */
+export const userInfoHandlerMismatchedSub = rest.get(
+  MOCK_USERINFO_ENDPOINT,
+  async (_req, res, ctx) => {
+    const data = await generateUserInfo()
+    return res(
+      ctx.status(200),
+      ctx.json({
+        sub: 'mismatchedSub',
+        data,
+      }),
+    )
+  },
+)
+
+/**
  * Handler to test case where userinfo endpoint does not return key
  */
 export const userInfoHandlerNoKey = rest.get(


### PR DESCRIPTION
## Problem

[OIDC spec](https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse) states that the RP must verify that the `sub` returned by the userinfo endpoint matches the `sub` in the ID token. Since this is a requirement for all RPs, the SDK should implement this check.

## Solution

Change the API of the `userinfo` method to include the `sub`, and check that the `sub` passed matches the `sub` returned by the userinfo endpoint.