### PR TITLE
feat(ci): update ci so that package is published upon merging to `release` branch

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -4,8 +4,9 @@
 name: Node.js Package
 
 on:
-  release:
-    types: [created]
+  push:
+    branches:
+      - release
 
 jobs:
   build:


### PR DESCRIPTION
# To-dos before merging
- [x] Create a `release` branch
- [x] Protect the `release` branch so that it can only be pushed via a pull request
- [x] Update [Typescript SDK release guide
](https://www.notion.so/opengov/Release-Guide-aa02a75ce1354e3b94e80f6181a02d70?pvs=4#65b91be97fa8452992d614b004ce396f)

# Problem
Currently, we publish to npm after a release is published on GitHub. This is dangerous because anyone on the sgID team can publish a release - there are no protections or approval flow surrounding publishing a release. This means that a bad actor only needs to compromise one account to release a new, malicious version of the SDK.

# Solution
This PR changes that by publishing to npm only upon merging to the release branch, which should be protected. 

See the [updated SDK release guide](https://www.notion.so/opengov/Release-Guide-aa02a75ce1354e3b94e80f6181a02d70?pvs=4#65b91be97fa8452992d614b004ce396f) for the Typescript SDK.
