### PR TITLE
docs: update example READMEs to point to the docs

### DIFF
--- a/examples/express/README.md
+++ b/examples/express/README.md
@@ -4,57 +4,13 @@ The example application code is in `index.ts`. You can copy this code to bootstr
 
 ## Running this example app locally
 
-### Prerequisites
-
-Register a new client at the [sgID developer portal](https://developer.id.gov.sg). For detailed instructions on how to register, check out our [documentation](https://docs.id.gov.sg/introduction/getting-started/register-your-application). Feel free to register a test client; there is no limit to the number of clients you can create.
-
-When registering a client, be sure to register the redirect URL to be `http://localhost:5001/api/redirect`, since this example runs on port `5001` by default.
-
-### Steps to run locally
-
-1. Clone this repo.
-
-```
-git clone https://github.com/opengovsg/sgid-client.git
-```
-
-2. Go to this folder and copy the contents of `.env.example` into a new file called `.env`.
-
-```
-cd sgid-client/examples/express
-cat .env.example > .env
-```
-
-3. Replace the values in `.env` with the credentials of your sgID client (see [Prerequisites](#prerequisites)).
-
-4. Run the Express app:
-
-```
-npm install
-npm start
-```
-
-This should start the server on port `5001` by default
-
-5. Clone sgID's example frontend repo:
-
-```
-git clone https://github.com/opengovsg/sgid-demo-frontend-spa.git
-```
-
-6. Install and run the example frontend:
-
-```
-cd sgid-demo-frontend-spa
-npm install
-npm run dev
-```
-
-This should start the frontend on port `5173` by default. Visit `http://localhost:5173` to test the entire sgID flow!
+Refer to sgID's [documentation](https://docs.id.gov.sg/integrations-with-sgid/typescript-javascript/framework-guides/express-with-single-page-app-frontend) for a detailed guide on what this example does and how to run it locally.
 
 ## For contributors
 
-To start the server in debug mode, run:
+### Local development
+
+To install the dependencies and start the server in debug mode, run:
 
 ```
 npm install

--- a/examples/express/README.md
+++ b/examples/express/README.md
@@ -8,7 +8,7 @@ The example application code is in `index.ts`. You can copy this code to bootstr
 
 Register a new client at the [sgID developer portal](https://developer.id.gov.sg). For detailed instructions on how to register, check out our [documentation](https://docs.id.gov.sg/introduction/getting-started/register-your-application). Feel free to register a test client; there is no limit to the number of clients you can create.
 
-When registering a client, be sure to register the callback URL to be `http://localhost:5001/api/callback`, since this example runs on port `5001` by default.
+When registering a client, be sure to register the redirect URL to be `http://localhost:5001/api/redirect`, since this example runs on port `5001` by default.
 
 ### Steps to run locally
 

--- a/examples/nextjs-csr/README.md
+++ b/examples/nextjs-csr/README.md
@@ -1,20 +1,19 @@
-# sgID Next.js (CSR) Example
+# Next.js (CSR) example sgID app
 
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+This example integrates the TypeScript SDK in a Next.js project using the pages router, api routes and client-side rendering (CSR). You can copy this code to bootstrap your sgID client application, and run this app locally to understand how this SDK helps you interact with the sgID server.
 
-## Getting Started
+## Running this example app locally
 
-Before you can run the development server, you will have to register your client on the sgID [developer portal](https://developer.id.gov.sg/).
+Refer to sgID's [documentation](https://docs.id.gov.sg/integrations-with-sgid/typescript-javascript/framework-guides/next.js-client-side-rendering) for a detailed guide on what this example does and how to run it locally.
 
-- For this example, you will need to include the following scopes `[openid, myinfo.name]` and register the following redirect URL `http://localhost:3000/api/redirect`
+## For contributors
 
-> For more information about sgID, please visit the [developer documentation](https://docs.id.gov.sg/).
+### Local development
 
-Copy the `.env.example` file, rename it to `.env`, and fill in your credentials obtained during registration.
+To install the dependencies and start the server in debug mode, run:
 
-Then, run the development server by running:
-
-```bash
+```
+npm install
 npm run dev
 ```
 

--- a/examples/nextjs-csr/README.md
+++ b/examples/nextjs-csr/README.md
@@ -6,7 +6,7 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 Before you can run the development server, you will have to register your client on the sgID [developer portal](https://developer.id.gov.sg/).
 
-- For this example, you will need to include the following scopes `[openid, myinfo.name]` and register the following redirect URL `http://localhost:3000/api/callback`
+- For this example, you will need to include the following scopes `[openid, myinfo.name]` and register the following redirect URL `http://localhost:3000/api/redirect`
 
 > For more information about sgID, please visit the [developer documentation](https://docs.id.gov.sg/).
 

--- a/examples/nextjs-ssr/README.md
+++ b/examples/nextjs-ssr/README.md
@@ -1,20 +1,19 @@
-# sgID Next.js (SSR) Example
+# Next.js (SSR) example sgID app
 
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+This example integrates the TypeScript SDK in a Next.js (>= 13.4) project using the app router, middleware, server components, and server-side rendering (SSR). You can copy this code to bootstrap your sgID client application, and run this app locally to understand how this SDK helps you interact with the sgID server.
 
-## Getting Started
+## Running this example app locally
 
-Before you can run the development server, you will have to register your client on the sgID [developer portal](https://developer.id.gov.sg/).
+Refer to sgID's [documentation](https://docs.id.gov.sg/integrations-with-sgid/typescript-javascript/framework-guides/next.js-server-side-rendering) for a detailed guide on what this example does and how to run it locally.
 
-- For this example, you will need to include the following scopes `[openid, myinfo.name]` and register the following redirect URL `http://localhost:3000/success`
+## For contributors
 
-> For more information about sgID, please visit the [developer documentation](https://docs.id.gov.sg/).
+### Local development
 
-Copy the `.env.example` file, rename it to `.env`, and fill in your credentials obtained during registration.
+To install the dependencies and start the server in debug mode, run:
 
-Then, run the development server by running:
-
-```bash
+```
+npm install
 npm run dev
 ```
 

--- a/test/mocks/constants.ts
+++ b/test/mocks/constants.ts
@@ -18,7 +18,7 @@ export const MOCK_JWKS_ENDPOINT = `${MOCK_ISSUER}/.well-known/jwks.json`
 // RP configuration
 export const MOCK_CLIENT_ID = 'mockClientId'
 export const MOCK_CLIENT_SECRET = 'mockClientSecret'
-export const MOCK_REDIRECT_URI = 'https://sgid.com/callback'
+export const MOCK_REDIRECT_URI = 'https://sgid.com/redirect'
 export const MOCK_CLIENT_PUBLIC_KEY = mockClientKeys.publicKey
 export const MOCK_CLIENT_PRIVATE_KEY = mockClientKeys.privateKey
 


### PR DESCRIPTION
Updated the example READMEs to point to the docs instead of listing the steps.

Additionally renamed a test constant from `/callback`to `/redirect`as part of the effort to standardize the usage of our terms.