### PR TITLE
chore: update port used for Next.js examples

### DIFF
--- a/examples/nextjs-csr/README.md
+++ b/examples/nextjs-csr/README.md
@@ -17,4 +17,4 @@ npm install
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:5001](http://localhost:5001) with your browser to see the result.

--- a/examples/nextjs-csr/package.json
+++ b/examples/nextjs-csr/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 5001",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p 5001",
     "lint": "next lint"
   },
   "dependencies": {

--- a/examples/nextjs-csr/src/lib/sgidClient.ts
+++ b/examples/nextjs-csr/src/lib/sgidClient.ts
@@ -4,7 +4,7 @@ const sgidClient = new SgidClient({
   clientId: String(process.env.SGID_CLIENT_ID),
   clientSecret: String(process.env.SGID_CLIENT_SECRET),
   privateKey: String(process.env.SGID_PRIVATE_KEY),
-  redirectUri: 'http://localhost:3000/api/redirect',
+  redirectUri: 'http://localhost:5001/api/redirect',
 })
 
 export { sgidClient }

--- a/examples/nextjs-ssr/README.md
+++ b/examples/nextjs-ssr/README.md
@@ -17,4 +17,4 @@ npm install
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:5001](http://localhost:5001) with your browser to see the result.

--- a/examples/nextjs-ssr/package.json
+++ b/examples/nextjs-ssr/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 5001",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p 5001",
     "lint": "next lint"
   },
   "dependencies": {

--- a/examples/nextjs-ssr/src/lib/sgidClient.ts
+++ b/examples/nextjs-ssr/src/lib/sgidClient.ts
@@ -4,7 +4,7 @@ const sgidClient = new SgidClient({
   clientId: String(process.env.SGID_CLIENT_ID),
   clientSecret: String(process.env.SGID_CLIENT_SECRET),
   privateKey: String(process.env.SGID_PRIVATE_KEY),
-  redirectUri: 'http://localhost:3000/success',
+  redirectUri: 'http://localhost:5001/success',
 })
 
 export { sgidClient }


### PR DESCRIPTION
This PR updates the port used for our Next.js CSR and SSR examples from `3000` to `5001`. 

`3000` is a commonly used port. We observed in our usability tests that when a user already has a process running on port `3000`, the Next.js example will then be run on a different port, and they will need to reconfigure quite a few things for the example to work (for example, they need to respecify their redirect URLs on both the dev portal and the sgID client initialization), which they might not know to do.