### PR TITLE
feat: expose generateNonce util

### DIFF
--- a/src/SgidClient.ts
+++ b/src/SgidClient.ts
@@ -1,5 +1,5 @@
 import { compactDecrypt, importJWK, importPKCS8 } from 'jose'
-import { Client, generators, Issuer } from 'openid-client'
+import { Client, Issuer } from 'openid-client'
 
 import {
   API_VERSION,
@@ -10,6 +10,7 @@ import {
   SGID_SUPPORTED_GRANT_TYPES,
 } from './constants'
 import * as Errors from './error'
+import { generateNonce } from './generators'
 import {
   AuthorizationUrlParams,
   AuthorizationUrlReturn,
@@ -98,7 +99,7 @@ export class SgidClient {
   authorizationUrl({
     state,
     scope = DEFAULT_SCOPE,
-    nonce = generators.nonce(),
+    nonce = generateNonce(),
     redirectUri = this.getFirstRedirectUri(),
     codeChallenge,
   }: AuthorizationUrlParams): AuthorizationUrlReturn {

--- a/src/generators.ts
+++ b/src/generators.ts
@@ -46,3 +46,12 @@ export function generateCodeVerifier(length = 43): string {
 export function generateCodeChallenge(codeVerifier: string): string {
   return generators.codeChallenge(codeVerifier)
 }
+
+/**
+ * Generates a nonce to include in the authorization URL. The nonce returned
+ * is base64-URL encoded.
+ * @param numBytes The number of random bytes to use to generate the nonce
+ */
+export function generateNonce(numBytes = 32): string {
+  return generators.nonce(numBytes)
+}

--- a/test/unit/SgidClient.spec.ts
+++ b/test/unit/SgidClient.spec.ts
@@ -4,6 +4,7 @@ import SgidClient from '../../src'
 import {
   generateCodeChallenge,
   generateCodeVerifier,
+  generateNonce,
   generatePkcePair,
 } from '../../src/generators'
 
@@ -497,6 +498,34 @@ describe('SgidClient', () => {
       const secondCodeChallenge = generateCodeChallenge(MOCK_CODE_VERIFIER)
 
       expect(firstCodeChallenge).toBe(secondCodeChallenge)
+    })
+  })
+
+  describe('generateNonce', () => {
+    it('should generate a nonce with 32 random bytes when no length is provided', () => {
+      const nonce = generateNonce()
+
+      // 32 bytes -> 10 groups of 3 bytes + 2 leftover -> 10 * 4 + 3 base64 characters,
+      // excluding padding
+      expect(nonce.length).toBe(43)
+    })
+
+    it('should generate a nonce of the specified number of random bytes', () => {
+      const numBytesToB64StrLength = (numBytes: number) => {
+        switch (numBytes % 3) {
+          case 0:
+            return (numBytes / 3) * 4
+          case 1:
+            return ((numBytes - 1) / 3) * 4 + 2
+          case 2:
+            return ((numBytes - 2) / 3) * 4 + 3
+        }
+      }
+      // Arbitrary start and end, just to check behaviour is correct
+      for (let numBytes = 32; numBytes <= 128; numBytes++) {
+        const nonce = generateNonce(numBytes)
+        expect(nonce.length).toBe(numBytesToB64StrLength(numBytes))
+      }
     })
   })
 })


### PR DESCRIPTION
Closes #61 

## Alternatives considered

**Use string length as an argument instead of number of bytes**
My concern with this was that the user wants control over how random they want the nonce to be, and string length doesn't give them direct control over that. This is because the length can vary based on encoding rather than actual underlying randomness.