### PR TITLE
feat: handle array data values

### DIFF
--- a/src/SgidClient.ts
+++ b/src/SgidClient.ts
@@ -256,7 +256,7 @@ export class SgidClient {
    * If a stringified array or object is passed in, then an array or object is returned
    * respectively.
    */
-  static parseData(dataValue: string): ParsedSgidDataValue {
+  parseData(dataValue: string): ParsedSgidDataValue {
     // JSON parse array data values if necessary
     if (isStringWrappedInSquareBrackets(dataValue)) {
       return safeJsonParse(dataValue)

--- a/src/SgidClient.ts
+++ b/src/SgidClient.ts
@@ -21,7 +21,11 @@ import {
   UserInfoParams,
   UserInfoReturn,
 } from './types'
-import { convertPkcs1ToPkcs8, isStringifiedObject, safeJsonParse } from './util'
+import {
+  convertPkcs1ToPkcs8,
+  isStringifiedArrayOrObject,
+  safeJsonParse,
+} from './util'
 
 export class SgidClient {
   private privateKey: string
@@ -254,7 +258,7 @@ export class SgidClient {
    */
   parseData(dataValue: string): ParsedSgidDataValue {
     // JSON parse array data values if necessary
-    if (isStringifiedObject(dataValue)) {
+    if (isStringifiedArrayOrObject(dataValue)) {
       return safeJsonParse(dataValue)
     }
     return dataValue

--- a/src/SgidClient.ts
+++ b/src/SgidClient.ts
@@ -21,11 +21,7 @@ import {
   UserInfoParams,
   UserInfoReturn,
 } from './types'
-import {
-  convertPkcs1ToPkcs8,
-  isStringWrappedInSquareBrackets,
-  safeJsonParse,
-} from './util'
+import { convertPkcs1ToPkcs8, isStringifiedObject, safeJsonParse } from './util'
 
 export class SgidClient {
   private privateKey: string
@@ -258,7 +254,7 @@ export class SgidClient {
    */
   parseData(dataValue: string): ParsedSgidDataValue {
     // JSON parse array data values if necessary
-    if (isStringWrappedInSquareBrackets(dataValue)) {
+    if (isStringifiedObject(dataValue)) {
       return safeJsonParse(dataValue)
     }
     return dataValue

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type SafelyParsedJson = string | unknown[] | Record<string, unknown>
+export type ParsedSgidDataValue = string | unknown[] | Record<string, unknown>
 
 export type AuthorizationUrlParams = {
   state?: string
@@ -26,7 +26,7 @@ export type UserInfoParams = {
 
 export type UserInfoReturn = {
   sub: string
-  data: Record<string, SafelyParsedJson>
+  data: Record<string, string>
 }
 
 export type SgidClientParams = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+export type SafelyParsedJson = string | unknown[] | Record<string, unknown>
+
 export type AuthorizationUrlParams = {
   state?: string
   scope?: string | string[]
@@ -24,7 +26,7 @@ export type UserInfoParams = {
 
 export type UserInfoReturn = {
   sub: string
-  data: Record<string, string>
+  data: Record<string, SafelyParsedJson>
 }
 
 export type SgidClientParams = {

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,12 +10,12 @@ export function convertPkcs1ToPkcs8(pkcs1: string): string {
   return key.exportKey('pkcs8')
 }
 
-export function isStringWrappedInSquareBrackets(
-  possibleArrayString: string,
-): boolean {
+export function isStringifiedObject(possibleObjectString: string): boolean {
   return (
-    possibleArrayString.charAt(0) === '[' &&
-    possibleArrayString.charAt(possibleArrayString.length - 1) === ']'
+    (possibleObjectString.charAt(0) === '[' &&
+      possibleObjectString.charAt(possibleObjectString.length - 1) === ']') ||
+    (possibleObjectString.charAt(0) === '{' &&
+      possibleObjectString.charAt(possibleObjectString.length - 1) === '}')
   )
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,12 +10,18 @@ export function convertPkcs1ToPkcs8(pkcs1: string): string {
   return key.exportKey('pkcs8')
 }
 
-export function isStringifiedObject(possibleObjectString: string): boolean {
+export function isStringifiedArrayOrObject(
+  possibleArrayOrObjectString: string,
+): boolean {
   return (
-    (possibleObjectString.charAt(0) === '[' &&
-      possibleObjectString.charAt(possibleObjectString.length - 1) === ']') ||
-    (possibleObjectString.charAt(0) === '{' &&
-      possibleObjectString.charAt(possibleObjectString.length - 1) === '}')
+    (possibleArrayOrObjectString.charAt(0) === '[' &&
+      possibleArrayOrObjectString.charAt(
+        possibleArrayOrObjectString.length - 1,
+      ) === ']') ||
+    (possibleArrayOrObjectString.charAt(0) === '{' &&
+      possibleArrayOrObjectString.charAt(
+        possibleArrayOrObjectString.length - 1,
+      ) === '}')
   )
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,6 @@
 import NodeRSA from 'node-rsa'
 
-import { SafelyParsedJson } from './types'
+import { ParsedSgidDataValue } from './types'
 
 /**
  * Convert PKCS1 PEM private key to PKCS8 PEM
@@ -19,7 +19,7 @@ export function isStringWrappedInSquareBrackets(
   )
 }
 
-export function safeJsonParse(jsonString: string): SafelyParsedJson {
+export function safeJsonParse(jsonString: string): ParsedSgidDataValue {
   try {
     return JSON.parse(jsonString)
   } catch (_) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,9 +1,28 @@
 import NodeRSA from 'node-rsa'
 
+import { SafelyParsedJson } from './types'
+
 /**
  * Convert PKCS1 PEM private key to PKCS8 PEM
  */
 export function convertPkcs1ToPkcs8(pkcs1: string): string {
   const key = new NodeRSA(pkcs1, 'pkcs1')
   return key.exportKey('pkcs8')
+}
+
+export function isStringWrappedInSquareBrackets(
+  possibleArrayString: string,
+): boolean {
+  return (
+    possibleArrayString.charAt(0) === '[' &&
+    possibleArrayString.charAt(possibleArrayString.length - 1) === ']'
+  )
+}
+
+export function safeJsonParse(jsonString: string): SafelyParsedJson {
+  try {
+    return JSON.parse(jsonString)
+  } catch (_) {
+    return jsonString
+  }
 }

--- a/test/unit/utils.spec.ts
+++ b/test/unit/utils.spec.ts
@@ -1,4 +1,4 @@
-import { isStringifiedObject, safeJsonParse } from '../../src/util'
+import { isStringifiedArrayOrObject, safeJsonParse } from '../../src/util'
 
 describe('util functions', () => {
   const exampleArray = ['a', 'b', 'c']
@@ -8,14 +8,14 @@ describe('util functions', () => {
   const exampleStringifiedObject = JSON.stringify(exampleObject)
   const exampleString = 'hello world'
 
-  describe('isStringifiedObject', () => {
+  describe('isStringifiedArrayOrObject', () => {
     it('should correctly identify stringified objects (both arrays and objects)', () => {
-      expect(isStringifiedObject(exampleStringifiedArray)).toBe(true)
-      expect(isStringifiedObject(corruptedStringifiedArray)).toBe(true)
-      expect(isStringifiedObject(exampleStringifiedObject)).toBe(true)
+      expect(isStringifiedArrayOrObject(exampleStringifiedArray)).toBe(true)
+      expect(isStringifiedArrayOrObject(corruptedStringifiedArray)).toBe(true)
+      expect(isStringifiedArrayOrObject(exampleStringifiedObject)).toBe(true)
     })
     it('should correctly reject strings that are not stringified arrays', () => {
-      expect(isStringifiedObject(exampleString)).toBe(false)
+      expect(isStringifiedArrayOrObject(exampleString)).toBe(false)
     })
   })
 

--- a/test/unit/utils.spec.ts
+++ b/test/unit/utils.spec.ts
@@ -1,0 +1,44 @@
+import { isStringWrappedInSquareBrackets, safeJsonParse } from '../../src/util'
+
+describe('util functions', () => {
+  const exampleArray = ['a', 'b', 'c']
+  const exampleStringifiedArray = JSON.stringify(exampleArray)
+  const corruptedStringifiedArray = '["a", ]]]]'
+  const exampleObject = { a: 'b' }
+  const exampleStringifiedObject = JSON.stringify(exampleObject)
+  const exampleString = 'hello world'
+
+  describe('isStringWrappedInSquareBrackets', () => {
+    it('should correctly identify strings wrapped in square brackets', () => {
+      expect(isStringWrappedInSquareBrackets(exampleStringifiedArray)).toBe(
+        true,
+      )
+      expect(isStringWrappedInSquareBrackets(corruptedStringifiedArray)).toBe(
+        true,
+      )
+    })
+    it('should correctly reject strings that are not stringified arrays', () => {
+      expect(isStringWrappedInSquareBrackets(exampleStringifiedObject)).toBe(
+        false,
+      )
+      expect(isStringWrappedInSquareBrackets(exampleString)).toBe(false)
+    })
+  })
+
+  describe('safeJsonParse', () => {
+    it('should correctly parse valid JSON strings', () => {
+      expect(JSON.stringify(safeJsonParse(exampleStringifiedArray))).toBe(
+        JSON.stringify(exampleArray),
+      )
+      expect(JSON.stringify(safeJsonParse(exampleStringifiedObject))).toBe(
+        JSON.stringify(exampleObject),
+      )
+    })
+    it('should return the original string if the input string is not a valid JSON string', () => {
+      expect(safeJsonParse(corruptedStringifiedArray)).toBe(
+        corruptedStringifiedArray,
+      )
+      expect(safeJsonParse(exampleString)).toBe(exampleString)
+    })
+  })
+})

--- a/test/unit/utils.spec.ts
+++ b/test/unit/utils.spec.ts
@@ -1,4 +1,4 @@
-import { isStringWrappedInSquareBrackets, safeJsonParse } from '../../src/util'
+import { isStringifiedObject, safeJsonParse } from '../../src/util'
 
 describe('util functions', () => {
   const exampleArray = ['a', 'b', 'c']
@@ -8,20 +8,14 @@ describe('util functions', () => {
   const exampleStringifiedObject = JSON.stringify(exampleObject)
   const exampleString = 'hello world'
 
-  describe('isStringWrappedInSquareBrackets', () => {
-    it('should correctly identify strings wrapped in square brackets', () => {
-      expect(isStringWrappedInSquareBrackets(exampleStringifiedArray)).toBe(
-        true,
-      )
-      expect(isStringWrappedInSquareBrackets(corruptedStringifiedArray)).toBe(
-        true,
-      )
+  describe('isStringifiedObject', () => {
+    it('should correctly identify stringified objects (both arrays and objects)', () => {
+      expect(isStringifiedObject(exampleStringifiedArray)).toBe(true)
+      expect(isStringifiedObject(corruptedStringifiedArray)).toBe(true)
+      expect(isStringifiedObject(exampleStringifiedObject)).toBe(true)
     })
     it('should correctly reject strings that are not stringified arrays', () => {
-      expect(isStringWrappedInSquareBrackets(exampleStringifiedObject)).toBe(
-        false,
-      )
-      expect(isStringWrappedInSquareBrackets(exampleString)).toBe(false)
+      expect(isStringifiedObject(exampleString)).toBe(false)
     })
   })
 


### PR DESCRIPTION
## Problem
When we introduce POCDEX as a data source, it will return an array of public officer profiles associated with the NRIC / FIN provided. However, sgID cannot currently process array data values because of how data is stored on the mobile application - for Android the data is stored as a key-value map (so the value needs to be a string) and for iOS, the data is stored in binary form. Therefore, the data value for array fields need to be stored as JSON strings.

## Solution
This PR mitigates this problem by adding a new `parseData` method that parses the sgID user data values returned from the SgidClient's `userinfo` method into arrays or objects if applicable. It does so by detecting whether the data string is wrapped in square brackets. The method performs a safe JSON parse so that if the data is successfully parsed, an array object is returned, and if not, the original string is returned.

The reason for making the data parsing step an explicit, separate step is to avoid making breaking changes for our SDK. If we modify the return type of the `userinfo` method, this would break existing RP implementations, since existing users expect a string to be returned as a data value.

In practice, there's no breaking change because no array data fields are currently available in sgID. However, it would still represent a change in the types returned for the user. It is also a cleaner interface to consistently return a string and allow the user to parse it if necessary.

## Tests
- I created new unit tests for the util functions introduced in this PR
- I also ran the OIDC conformance test completely with no failed tests
- I ran the example app with the new client together with the `sgidthirdpartymock.public_officer_employments` scope