### PR TITLE
feat: expose id token

### DIFF
--- a/src/SgidClient.ts
+++ b/src/SgidClient.ts
@@ -160,7 +160,7 @@ export class SgidClient {
     const { sub } = tokenSet.claims()
     const { access_token: accessToken, id_token: idToken } = tokenSet
     if (!isNonEmptyString(idToken)) {
-      throw new Error(Errors.NO_ID_TOKEN_ERROR)
+      throw new Error(Errors.INVALID_ID_TOKEN_ERROR)
     }
     if (!sub) {
       throw new Error(Errors.NO_SUB_ERROR)

--- a/src/SgidClient.ts
+++ b/src/SgidClient.ts
@@ -23,6 +23,7 @@ import {
 } from './types'
 import {
   convertPkcs1ToPkcs8,
+  isNonEmptyString,
   isStringifiedArrayOrObject,
   safeJsonParse,
 } from './util'
@@ -158,7 +159,7 @@ export class SgidClient {
     )
     const { sub } = tokenSet.claims()
     const { access_token: accessToken, id_token: idToken } = tokenSet
-    if (!idToken) {
+    if (!isNonEmptyString(idToken)) {
       throw new Error(Errors.NO_ID_TOKEN_ERROR)
     }
     if (!sub) {

--- a/src/SgidClient.ts
+++ b/src/SgidClient.ts
@@ -158,10 +158,12 @@ export class SgidClient {
     )
     const { sub } = tokenSet.claims()
 
-    // Note that validation is not done on the id token because the nodejs
-    // openid-client library already does it for us
     const { access_token: accessToken, id_token: idToken } = tokenSet
 
+    // Note that this falsey check for the id token will never be run
+    // because the nodejs openid-client library already does it for us
+    // Doing a check here just for type safety
+    if (!idToken) throw new Error(Errors.NO_ID_TOKEN_ERROR)
     if (!sub) {
       throw new Error(Errors.NO_SUB_ERROR)
     }

--- a/src/SgidClient.ts
+++ b/src/SgidClient.ts
@@ -157,14 +157,17 @@ export class SgidClient {
       { nonce: nonce ?? undefined, code_verifier: codeVerifier },
     )
     const { sub } = tokenSet.claims()
-    const { access_token: accessToken } = tokenSet
+    const { access_token: accessToken, id_token: idToken } = tokenSet
+    if (!idToken) {
+      throw new Error(Errors.NO_ID_TOKEN_ERROR)
+    }
     if (!sub) {
       throw new Error(Errors.NO_SUB_ERROR)
     }
     if (!accessToken) {
       throw new Error(Errors.NO_ACCESS_TOKEN_ERROR)
     }
-    return { sub, accessToken }
+    return { sub, accessToken, idToken }
   }
 
   /**

--- a/src/SgidClient.ts
+++ b/src/SgidClient.ts
@@ -23,7 +23,6 @@ import {
 } from './types'
 import {
   convertPkcs1ToPkcs8,
-  isNonEmptyString,
   isStringifiedArrayOrObject,
   safeJsonParse,
 } from './util'
@@ -158,10 +157,11 @@ export class SgidClient {
       { nonce: nonce ?? undefined, code_verifier: codeVerifier },
     )
     const { sub } = tokenSet.claims()
+
+    // Note that validation is not done on the id token because the nodejs
+    // openid-client library already does it for us
     const { access_token: accessToken, id_token: idToken } = tokenSet
-    if (!isNonEmptyString(idToken)) {
-      throw new Error(Errors.INVALID_ID_TOKEN_ERROR)
-    }
+
     if (!sub) {
       throw new Error(Errors.NO_SUB_ERROR)
     }

--- a/src/error.ts
+++ b/src/error.ts
@@ -12,8 +12,6 @@ export const MISSING_REDIRECT_URI_ERROR =
 export const NO_SUB_ERROR = 'Authorization server did not return the sub claim'
 export const NO_ACCESS_TOKEN_ERROR =
   'Authorization server did not return an access token'
-export const INVALID_ID_TOKEN_ERROR =
-  'sgID token endpoint did not return a valid ID token. Expected a non-empty string.'
 
 // userinfo errors
 export const PRIVATE_KEY_IMPORT_ERROR =

--- a/src/error.ts
+++ b/src/error.ts
@@ -12,6 +12,8 @@ export const MISSING_REDIRECT_URI_ERROR =
 export const NO_SUB_ERROR = 'Authorization server did not return the sub claim'
 export const NO_ACCESS_TOKEN_ERROR =
   'Authorization server did not return an access token'
+export const NO_ID_TOKEN_ERROR =
+  'Authorization server did not return an id token'
 
 // userinfo errors
 export const PRIVATE_KEY_IMPORT_ERROR =

--- a/src/error.ts
+++ b/src/error.ts
@@ -12,7 +12,7 @@ export const MISSING_REDIRECT_URI_ERROR =
 export const NO_SUB_ERROR = 'Authorization server did not return the sub claim'
 export const NO_ACCESS_TOKEN_ERROR =
   'Authorization server did not return an access token'
-export const NO_ID_TOKEN_ERROR =
+export const INVALID_ID_TOKEN_ERROR =
   'sgID token endpoint did not return a valid ID token. Expected a non-empty string.'
 
 // userinfo errors

--- a/src/error.ts
+++ b/src/error.ts
@@ -12,6 +12,8 @@ export const MISSING_REDIRECT_URI_ERROR =
 export const NO_SUB_ERROR = 'Authorization server did not return the sub claim'
 export const NO_ACCESS_TOKEN_ERROR =
   'Authorization server did not return an access token'
+export const NO_ID_TOKEN_ERROR =
+  'Authorization server did not return an ID token'
 
 // userinfo errors
 export const PRIVATE_KEY_IMPORT_ERROR =

--- a/src/error.ts
+++ b/src/error.ts
@@ -13,7 +13,7 @@ export const NO_SUB_ERROR = 'Authorization server did not return the sub claim'
 export const NO_ACCESS_TOKEN_ERROR =
   'Authorization server did not return an access token'
 export const NO_ID_TOKEN_ERROR =
-  'Authorization server did not return an id token'
+  'sgID token endpoint did not return a valid ID token. Expected a non-empty string.'
 
 // userinfo errors
 export const PRIVATE_KEY_IMPORT_ERROR =

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,11 @@ export type CallbackParams = {
   codeVerifier: string
 }
 
-export type CallbackReturn = { sub: string; accessToken: string }
+export type CallbackReturn = {
+  sub: string
+  accessToken: string
+  idToken: string
+}
 
 export type UserInfoParams = {
   sub: string

--- a/src/util.ts
+++ b/src/util.ts
@@ -25,6 +25,12 @@ export function isStringifiedArrayOrObject(
   )
 }
 
+export function isNonEmptyString(value: unknown): value is string {
+  if (typeof value !== 'string') return false
+  if (value === '') return false
+  return true
+}
+
 export function safeJsonParse(jsonString: string): ParsedSgidDataValue {
   try {
     return JSON.parse(jsonString)

--- a/test/unit/SgidClient.spec.ts
+++ b/test/unit/SgidClient.spec.ts
@@ -22,6 +22,7 @@ import {
   MOCK_USERINFO_PLAINTEXT,
 } from './mocks/constants'
 import {
+  tokenHandlerNoIdToken,
   tokenHandlerNoSub,
   tokenHandlerNoToken,
   userInfoHandlerMalformedData,
@@ -325,6 +326,17 @@ describe('SgidClient', () => {
           codeVerifier: MOCK_CODE_VERIFIER,
         }),
       ).rejects.toThrow('Authorization server did not return an access token')
+    })
+
+    it('should throw when no ID token is returned', async () => {
+      server.use(tokenHandlerNoIdToken)
+
+      await expect(
+        client.callback({
+          code: MOCK_AUTH_CODE,
+          codeVerifier: MOCK_CODE_VERIFIER,
+        }),
+      ).rejects.toThrow('id_token not present in TokenSet')
     })
 
     it('should throw when sub is empty', async () => {

--- a/test/unit/mocks/handlers.ts
+++ b/test/unit/mocks/handlers.ts
@@ -68,6 +68,21 @@ export const tokenHandlerNoToken = rest.post(
 )
 
 /**
+ * Handler to test case where server doesn't return an id token
+ */
+export const tokenHandlerNoIdToken = rest.post(
+  MOCK_TOKEN_ENDPOINT,
+  (_req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json({
+        access_token: MOCK_ACCESS_TOKEN,
+      }),
+    )
+  },
+)
+
+/**
  * Handler to test case where sub is empty
  */
 export const tokenHandlerNoSub = rest.post(


### PR DESCRIPTION
## Overview

This PR does 2 things:
1. Expose the id token as part of the callback() method 
2. Perform validation on the id token in a manner consistent across SDKs

### 1. Expose the ID token as part of the `callback()` method

Currently, we only expose the `sub` and access token after performing all the requisite checks on the ID token. But the id token is useful because it acts as proof that the user has been authenticated by sgID. Some relying parties want to store
the ID token as part of their audit trail. This is why we're exposing the ID token here.

### 2. Perform validation on the id token in a manner consistent across SDKs

Validation is done according to the SDK implementation strategy here: https://www.notion.so/opengov/SDK-implementation-requirements-1f9b7cbd2bd4406b85d6645fe3e365dd 

Note that in this case, the `openid-client` library does validation on the ID token for us, so behavior deviates from the Python SDK.

## Tests

- Tested locally that the `idToken` is received with [sgid-demo-frontend-spa](https://github.com/opengovsg/sgid-demo-frontend-spa) and the Express example in this repo.
- Added unit tests
