### PR TITLE
feat: parse sgid userinfo data

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -23,3 +23,7 @@ export const DECRYPT_BLOCK_KEY_ERROR =
 export const DECRYPT_PAYLOAD_ERROR = 'Unable to decrypt payload'
 export const SUB_MISMATCH_ERROR =
   'Sub returned by sgID did not match the sub passed to the userinfo method. Check that you passed the correct sub to the userinfo method.'
+
+// parseData errors
+export const INVALID_SGID_USERINFO_DATA_ERROR =
+  'Failed to parse sgID userinfo data object. Check that the input is a valid object.'

--- a/src/util.ts
+++ b/src/util.ts
@@ -38,3 +38,25 @@ export function safeJsonParse(jsonString: string): ParsedSgidDataValue {
     return jsonString
   }
 }
+
+function isDefinedObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    value !== undefined &&
+    !Array.isArray(value)
+  )
+}
+
+export function isSgidUserinfoObject(
+  data: unknown,
+): data is Record<string, string> {
+  if (!isDefinedObject(data)) {
+    return false
+  }
+
+  // Note that we don't need to check for the key being a string, because
+  // in Javascript all object keys are coerced into strings when you attempt
+  // to access them
+  return Object.values(data).every((value) => typeof value === 'string')
+}


### PR DESCRIPTION
This PR adds a new method, `parseData`, which helps to parse the sgID userinfo object so that any stringified array or object values are parsed as objects. Previously, the `parseData` object only parsed individual values.

This PR is implemented according to the SDK implementation requirements as linked here: https://www.notion.so/opengov/SDK-implementation-requirements-1f9b7cbd2bd4406b85d6645fe3e365dd#dcabe67d14034525bfd5e84acc1c59c6
    
This PR also adds the necessary unit tests for the newly introduced utility functions that support `parseData`
