### PR TITLE
fix: use actions cache v4 to fix the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: '16.x'
       - name: Cache Node.js modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.npm
@@ -35,7 +35,7 @@ jobs:
         with:
           node-version: '16.x'
       - name: Cache Node.js modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.npm


### PR DESCRIPTION
`actions/cache@v2` is deprecated hence CI is broken.
This PR uses `actions/cache@v4` which should not break anything.